### PR TITLE
Cancer Related Medication Request STU2 update

### DIFF
--- a/src/mapping/mappers/SyntheaToSTU2.js
+++ b/src/mapping/mappers/SyntheaToSTU2.js
@@ -10,7 +10,7 @@ const allRelevantProfiles = [
   'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-genetic-variant',
   'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-genomics-report',
   'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient',
-  'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-statement',
+  'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-request',
   'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-course-summary',
   'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-surgical-procedure',
   'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-comorbid-condition',
@@ -551,27 +551,17 @@ const resourceMapping = {
       filter:
         'MedicationRequest.medicationCodeableConcept.coding.where($this.code in %medicationCodes)',
       exec: (resource, _context) => {
-        const converted = {
-          resourceType: 'MedicationStatement',
-          id: resource.id,
-          meta: {
-            profile: [
-              'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-statement',
-            ],
-          },
-          status: resource.status,
-          medicationCodeableConcept: resource.medicationCodeableConcept,
-          subject: resource.subject,
-          context: resource.context,
-          effectiveDateTime: resource.authoredOn,
-        };
+        applyProfile(
+          resource,
+          'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-request'
+        );
 
-        if (converted.status === 'stopped') {
-          converted.status = 'completed';
+        if (resource.status === 'stopped') {
+          resource.status = 'completed';
         }
 
-        return converted;
-      },
+        return resource;
+      }
     },
     {
       filter: 'MedicationRequest',

--- a/src/mapping/mappers/SyntheaToSTU2.js
+++ b/src/mapping/mappers/SyntheaToSTU2.js
@@ -11,6 +11,7 @@ const allRelevantProfiles = [
   'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-genomics-report',
   'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient',
   'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-request',
+  'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-administration',
   'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-radiotherapy-course-summary',
   'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-surgical-procedure',
   'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-comorbid-condition',
@@ -573,6 +574,18 @@ const resourceMapping = {
 
         return resource;
       },
+    },
+    {
+      filter:
+        'MedicationAdministration.medicationCodeableConcept.coding.where($this.code in %medicationCodes)',
+      exec: (resource, _context) => {
+        applyProfile(
+          resource,
+          'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-related-medication-administration'
+        );
+
+        return resource;
+      }
     },
     {
       filter: "Observation.code.coding.where($this.code = '44667-4')",


### PR DESCRIPTION
This PR updates Cancer Related Medication profiles in the `SyntheaToSTU2` mapper. In STU1 there was just Cancer Related Medication Statement, which the mapper made by converting Synthea's US core medication requests. Now with STU2 having Cancer Related Medication Request (based on the US core med request), mapping is just applying the profile to applicable MedicationRequest resources.

Note: Only MedicationRequests with codes listed in `medicationCodes` in `mcodeUtils10.js` get converted to Cancer Related Medication Requests. I couldn't tell if this needed to be updated. Maybe something to look into in STEAM-869 when checking all the valuesets?

~~STU2 also introduced Cancer Related Medication Administration which is a renaming of the previous Cancer Related Medication Statement, but since the Synthea bundles already have Medication Requests, we decided it made sense to just map Cancer Related Medication Requests, since the Administrations would just consist of the same info, making them redundant. Additionally mapping the US Core Requests from Synthea to Cancer Related Medication Requests and Administrations would require implementing one-to-many mapping (one resource in Synthea converted to two resources in mCODE STU2) which would require a bigger change to the base functionality of the fhir-mapper. If we decide we want to map to both Request and Administration we should talk about how the one-to-many mapping would work~~ See below

To test, run the mapper and see that Medication Requests and Administrations are properly mapped and double check that I didn't miss any necessary changes in the mapping process