### PR TITLE
STU2 Comorbidities Elixhauser Profile support

### DIFF
--- a/src/mapping/mapper.js
+++ b/src/mapping/mapper.js
@@ -140,14 +140,14 @@ class AggregateMapper {
         } else {
           additionalEntries.push(
             ...mappedResources.slice(1, mappedResources.length + 1)
-            .map(mappedResource => {
-              return {resource: mappedResource}
-            }));
+              .map(mappedResource => {
+                return {resource: mappedResource};
+              }));
           return {
             fullUrl,
             resource: mappedResources[0],
             request
-          }
+          };
         }
       });
       resource.entry.push(...additionalEntries);

--- a/src/mapping/mapper.js
+++ b/src/mapping/mapper.js
@@ -127,14 +127,31 @@ class AggregateMapper {
     if (Array.isArray(resource)){
       return resource.map( r => this.execute(r, context)).filter(n => n);
     } else if (resource.resourceType === 'Bundle') {
+      const additionalEntries = [];
       resource.entry = resource.entry.map(e => {
         const { fullUrl, request, resource: entryResource } = e;
-        return {
-          fullUrl,
-          resource: this.execute(entryResource, context),
-          request
-        };
-      }).filter(e => e.resource);
+        const mappedResources = this.execute(entryResource, context);
+        if (!Array.isArray(mappedResources)) {
+          return {
+            fullUrl,
+            resource: this.execute(entryResource, context),
+            request
+          };
+        } else {
+          additionalEntries.push(
+            ...mappedResources.slice(1, mappedResources.length + 1)
+            .map(mappedResource => {
+              return {resource: mappedResource}
+            }));
+          return {
+            fullUrl,
+            resource: mappedResources[0],
+            request
+          }
+        }
+      });
+      resource.entry.push(...additionalEntries);
+      resource.entry = resource.entry.filter(e => e.resource);
       return resource;
     } else {
       // If we're supposed to ignore this resource, or if the filter, just return unmodified resource

--- a/src/mapping/mappers/SyntheaToSTU2.js
+++ b/src/mapping/mappers/SyntheaToSTU2.js
@@ -203,24 +203,24 @@ const resourceMapping = {
         );
         if (comorbidConditions.length > 0) {
           const comorbidObservation = {
-              resourceType: 'Observation',
-              meta: {
-                profile: [
-                  'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-comorbidities-elixhauser',
-                ],
-              },
-              status: 'final',
-              code: {
-                coding: [
-                  {
-                    system:
-                      'http://hl7.org/fhir/us/mcode/CodeSystem/loinc-requested-cs',
-                    code: 'comorbidities-elixhauser',
-                    display: 'Elixhauser Comorbidity Panel',
-                  },
-                ],
-              },
-              component: [],
+            resourceType: 'Observation',
+            meta: {
+              profile: [
+                'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-comorbidities-elixhauser',
+              ],
+            },
+            status: 'final',
+            code: {
+              coding: [
+                {
+                  system:
+                    'http://hl7.org/fhir/us/mcode/CodeSystem/loinc-requested-cs',
+                  code: 'comorbidities-elixhauser',
+                  display: 'Elixhauser Comorbidity Panel',
+                },
+              ],
+            },
+            component: [],
           };
 
           comorbidConditions.forEach((condition) => {


### PR DESCRIPTION
Updates the `SyntheaToSTU2` mapper to map Comorbid Conditions onto the new-to-STU2 [Comorbidities Elixhauser Profile](https://hl7.org/fhir/us/mcode/StructureDefinition-mcode-comorbidities-elixhauser.html) rather than into Comorbid Condition resources which have been removed in STU2. In this new profile, multiple comorbid conditions are included in a single Observation, with an entry in the `component` element corresponding to each condition. 