### PR TITLE
Tumor Marker Test STU2 fix

### DIFF
--- a/src/utils/valueSets/mcodeSTU2/mcode-tumor-marker-test-vs.json
+++ b/src/utils/valueSets/mcodeSTU2/mcode-tumor-marker-test-vs.json
@@ -1,0 +1,4154 @@
+{
+  "id": "mcode-tumor-marker-test-vs",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include these codes as defined in <a href=\"http://loinc.org\"><code>http://loinc.org</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/62320-7.html\">62320-7</a></td><td>T-cell receptor excision circle [#/volume] in DBS by NAA with probe detection</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/92006-6.html\">92006-6</a></td><td>T-cell receptor excision circle [Cycle Threshold #] in DBS</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/92007-4.html\">92007-4</a></td><td>T-cell receptor excision circle [Z-score] in DBS</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/92008-2.html\">92008-2</a></td><td>T-cell receptor excision circle [Multiple of the median] in DBS</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/69361-4.html\">69361-4</a></td><td>PCA3 score in Urine by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/69362-2.html\">69362-2</a></td><td>PCA3 score in Urine Qualitative by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19163-5.html\">19163-5</a></td><td>Cancer Ag 19-9 [Units/volume] in Pleural fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2009-9.html\">2009-9</a></td><td>Cancer Ag 19-9 [Presence] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/24108-3.html\">24108-3</a></td><td>Cancer Ag 19-9 [Units/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/26924-1.html\">26924-1</a></td><td>Cancer Ag 19-9 [Units/volume] in Body fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/50779-8.html\">50779-8</a></td><td>Cancer Ag 19-9 [Units/volume] in Cerebral spinal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/50780-6.html\">50780-6</a></td><td>Cancer Ag 19-9 [Units/volume] in Pericardial fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/50781-4.html\">50781-4</a></td><td>Cancer Ag 19-9 [Units/volume] in Peritoneal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/83084-4.html\">83084-4</a></td><td>Cancer Ag 19-9 [Units/volume] in Serum or Plasma by Immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/97750-4.html\">97750-4</a></td><td>Cancer Ag 19-9 [Units/volume] in Aspirate</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/14041-8.html\">14041-8</a></td><td>Choriogonadotropin.beta subunit [Units/volume] in Cerebral spinal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19174-2.html\">19174-2</a></td><td>Choriogonadotropin.beta subunit [Units/volume] in Amniotic fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19175-9.html\">19175-9</a></td><td>Choriogonadotropin.beta subunit [Moles/volume] in Amniotic fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/20415-6.html\">20415-6</a></td><td>Choriogonadotropin.beta subunit [Units/volume] in Serum or Plasma by Immunoassay (EIA) 3rd IS</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2111-3.html\">2111-3</a></td><td>Choriogonadotropin.beta subunit [Moles/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2113-9.html\">2113-9</a></td><td>Choriogonadotropin.beta subunit [Mass/time] in 24 hour Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2114-7.html\">2114-7</a></td><td>Choriogonadotropin.beta subunit [Moles/volume] in Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/21198-7.html\">21198-7</a></td><td>Choriogonadotropin.beta subunit [Units/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/29154-2.html\">29154-2</a></td><td>Choriogonadotropin.beta subunit [Units/volume] in Body fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/43799-6.html\">43799-6</a></td><td>Choriogonadotropin.beta subunit [Presence] in Specimen</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/43800-2.html\">43800-2</a></td><td>Choriogonadotropin.beta subunit [Presence] in Cerebral spinal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/55868-4.html\">55868-4</a></td><td>Choriogonadotropin.beta subunit [Multiple of the median] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/55869-2.html\">55869-2</a></td><td>Choriogonadotropin.beta subunit [Mass/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/56497-1.html\">56497-1</a></td><td>Choriogonadotropin.beta subunit [Units] in 24 hour Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/66762-6.html\">66762-6</a></td><td>Choriogonadotropin.beta subunit [Units/volume] in Pleural fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/66763-4.html\">66763-4</a></td><td>Choriogonadotropin.beta subunit [Units/volume] in Peritoneal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/10334-1.html\">10334-1</a></td><td>Cancer Ag 125 [Units/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/11210-2.html\">11210-2</a></td><td>Cancer Ag 125 [Units/volume] in Body fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/15156-3.html\">15156-3</a></td><td>Cancer Ag 125 [Units/volume] in Body fluid by Dilution</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/15157-1.html\">15157-1</a></td><td>Cancer Ag 125 [Units/volume] in Serum or Plasma by Dilution</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19165-0.html\">19165-0</a></td><td>Cancer Ag 125 [Units/volume] in Pleural fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2006-5.html\">2006-5</a></td><td>Cancer Ag 125 [Presence] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/40618-1.html\">40618-1</a></td><td>Cancer Ag 125 [Units/volume] in Peritoneal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/48677-9.html\">48677-9</a></td><td>Cancer Ag 125 [Presence] in Tissue by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/50775-6.html\">50775-6</a></td><td>Cancer Ag 125 [Units/volume] in Cerebral spinal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/59040-6.html\">59040-6</a></td><td>Cancer Ag 125 [Units/volume] in Peritoneal dialysis fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/68923-2.html\">68923-2</a></td><td>Cancer Ag 125 [Units/volume] in Pericardial fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/83082-8.html\">83082-8</a></td><td>Cancer Ag 125 [Units/volume] in Serum or Plasma by Immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/97743-9.html\">97743-9</a></td><td>Cancer Ag 125 [Units/volume] in Aspirate</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/15035-9.html\">15035-9</a></td><td>Calcitonin [Moles/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/1992-7.html\">1992-7</a></td><td>Calcitonin [Mass/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/47369-4.html\">47369-4</a></td><td>Calcitonin [Mass/volume] in Body fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/75709-6.html\">75709-6</a></td><td>Calcitonin [Mass/volume] in Lymph node fine needle aspirate</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/25587-7.html\">25587-7</a></td><td>Chromogranin A [Moles/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/30169-7.html\">30169-7</a></td><td>Chromogranin A [Units/volume] in Serum or Plasma by Immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/53047-7.html\">53047-7</a></td><td>Chromogranin A [Mass/volume] in Body fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/59220-4.html\">59220-4</a></td><td>Chromogranin A [Units/volume] in Pleural fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/59226-1.html\">59226-1</a></td><td>Chromogranin A [Units/volume] in Peritoneal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/59227-9.html\">59227-9</a></td><td>Chromogranin A [Units/volume] in Cerebral spinal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/59241-0.html\">59241-0</a></td><td>Chromogranin A [Units/volume] in Body fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/9811-1.html\">9811-1</a></td><td>Chromogranin A [Mass/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/15060-7.html\">15060-7</a></td><td>Enolase.neuron specific [Mass/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19193-2.html\">19193-2</a></td><td>Enolase.neuron specific [Units/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19194-0.html\">19194-0</a></td><td>Enolase.neuron specific [Units/volume] in Pleural fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2225-1.html\">2225-1</a></td><td>Enolase.neuron specific [Enzymatic activity/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/44802-7.html\">44802-7</a></td><td>Enolase.neuron specific [Mass/volume] in Cerebral spinal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/47053-4.html\">47053-4</a></td><td>Enolase.neuron specific [Mass/volume] in Cerebral spinal fluid by Immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/48138-2.html\">48138-2</a></td><td>Enolase.neuron specific [Mass/volume] in Serum or Plasma by Radioimmunoassay (RIA)</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/48164-8.html\">48164-8</a></td><td>Enolase.neuron specific [Mass/volume] in Body fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/57371-7.html\">57371-7</a></td><td>Enolase.neuron specific [Mass/volume] in Serum or Plasma by Immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/68939-8.html\">68939-8</a></td><td>Enolase.neuron specific [Mass/volume] in Pleural fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/68952-1.html\">68952-1</a></td><td>Enolase.neuron specific [Mass/volume] in Pericardial fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/69560-1.html\">69560-1</a></td><td>Enolase.neuron specific [Mass/volume] in Peritoneal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/97744-7.html\">97744-7</a></td><td>Enolase.neuron specific [Mass/volume] in Aspirate</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/15072-2.html\">15072-2</a></td><td>Gastrin [Moles/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2333-3.html\">2333-3</a></td><td>Gastrin [Mass/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2960-3.html\">2960-3</a></td><td>Somatostatin [Presence] in Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2961-1.html\">2961-1</a></td><td>Somatostatin [Mass/volume] in Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/49792-5.html\">49792-5</a></td><td>Somatostatin [Moles/volume] in Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/14918-7.html\">14918-7</a></td><td>Thyroglobulin [Moles/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/3013-0.html\">3013-0</a></td><td>Thyroglobulin [Mass/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/53920-5.html\">53920-5</a></td><td>Thyroglobulin [Mass/volume] in Lymph node fine needle aspirate</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/53922-1.html\">53922-1</a></td><td>Thyroglobulin [Mass/volume] in Tissue fine needle aspirate</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/97640-7.html\">97640-7</a></td><td>Thyroglobulin [Moles/volume] in Tissue fine needle aspirate</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/10861-3.html\">10861-3</a></td><td>Progesterone receptor [Mass/mass] in Tissue</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/16113-3.html\">16113-3</a></td><td>Progesterone receptor [Interpretation] in Tissue</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/31207-4.html\">31207-4</a></td><td>Progesterone receptor [Moles/mass] in Tissue</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/10873-8.html\">10873-8</a></td><td>Beta-2-Microglobulin [Mass/time] in 24 hour Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/14626-6.html\">14626-6</a></td><td>Beta-2-Microglobulin [Moles/volume] in Serum</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/1951-3.html\">1951-3</a></td><td>Beta-2-Microglobulin [Mass/volume] in Cerebral spinal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/1952-1.html\">1952-1</a></td><td>Beta-2-Microglobulin [Mass/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/1953-9.html\">1953-9</a></td><td>Beta-2-Microglobulin [Mass/volume] in Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/32301-4.html\">32301-4</a></td><td>Beta-2-Microglobulin [Moles/volume] in Cerebral spinal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/32302-2.html\">32302-2</a></td><td>Beta-2-Microglobulin [Moles/volume] in Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/39458-5.html\">39458-5</a></td><td>Beta-2-Microglobulin [Moles/volume] in Body fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/43818-4.html\">43818-4</a></td><td>Beta-2-Microglobulin [Presence] in Serum</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/43819-2.html\">43819-2</a></td><td>Beta-2-Microglobulin [Presence] in Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/43919-0.html\">43919-0</a></td><td>Beta-2-Microglobulin [Presence] in Cerebral spinal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/48166-3.html\">48166-3</a></td><td>Beta-2-Microglobulin [Mass/volume] in Body fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/49081-3.html\">49081-3</a></td><td>Beta-2-Microglobulin [Mass/volume] in Dialysis fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/50824-2.html\">50824-2</a></td><td>Beta-2-Microglobulin [Moles/volume] in 24 hour Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/54356-1.html\">54356-1</a></td><td>Beta-2-Microglobulin [Mass/volume] in 24 hour Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/56662-0.html\">56662-0</a></td><td>Beta-2-Microglobulin [Moles/time] in 24 hour Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/59217-0.html\">59217-0</a></td><td>Beta-2-Microglobulin [Mass/volume] in Peritoneal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/59218-8.html\">59218-8</a></td><td>Beta-2-Microglobulin [Mass/volume] in Pleural fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/76484-5.html\">76484-5</a></td><td>Beta-2-Microglobulin [Moles/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/83076-0.html\">83076-0</a></td><td>Beta-2-Microglobulin [Units/volume] in Serum or Plasma by Immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/83077-8.html\">83077-8</a></td><td>Beta-2-Microglobulin [Mass/volume] in Urine by Immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/83078-6.html\">83078-6</a></td><td>Beta-2-Microglobulin [Mass/volume] in Serum or Plasma by Immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/83079-4.html\">83079-4</a></td><td>Beta-2-Microglobulin [Units/volume] in Urine by Immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/88711-7.html\">88711-7</a></td><td>Beta-2-Microglobulin [Mass/volume] in Peritoneal dialysis fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/11053-6.html\">11053-6</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Red Blood Cells</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/14403-0.html\">14403-0</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Gastric fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/14803-1.html\">14803-1</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Body fluid by Lactate to pyruvate reaction</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/14804-9.html\">14804-9</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Serum or Plasma by Lactate to pyruvate reaction</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/14805-6.html\">14805-6</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Serum or Plasma by Pyruvate to lactate reaction</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/17041-5.html\">17041-5</a></td><td>Lactate dehydrogenase [Presence] in Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2527-0.html\">2527-0</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Amniotic fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2528-8.html\">2528-8</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Cerebral spinal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2529-6.html\">2529-6</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Body fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2530-4.html\">2530-4</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Pleural fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2531-2.html\">2531-2</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Peritoneal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2532-0.html\">2532-0</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2533-8.html\">2533-8</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Synovial fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2534-6.html\">2534-6</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/32324-6.html\">32324-6</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Specimen</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/33367-4.html\">33367-4</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Pericardial fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/47678-8.html\">47678-8</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in 24 hour Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/47863-6.html\">47863-6</a></td><td>Lactate dehydrogenase [Enzymatic activity/time] in 24 hour Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/57664-5.html\">57664-5</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Semen</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/5921-2.html\">5921-2</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Dialysis fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/60017-1.html\">60017-1</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Body fluid by Pyruvate to lactate reaction</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/60018-9.html\">60018-9</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Pericardial fluid by Pyruvate to lactate reaction</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/60019-7.html\">60019-7</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Pericardial fluid by Lactate to pyruvate reaction</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/60020-5.html\">60020-5</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Peritoneal fluid by Pyruvate to lactate reaction</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/60021-3.html\">60021-3</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Pleural fluid by Pyruvate to lactate reaction</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/60022-1.html\">60022-1</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Pleural fluid by Lactate to pyruvate reaction</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/60023-9.html\">60023-9</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Cerebral spinal fluid by Pyruvate to lactate reaction</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/60024-7.html\">60024-7</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Cerebral spinal fluid by Lactate to pyruvate reaction</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/68387-0.html\">68387-0</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Peritoneal fluid by Lactate to pyruvate reaction</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/68452-2.html\">68452-2</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Synovial fluid by Pyruvate to lactate reaction</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/68453-0.html\">68453-0</a></td><td>Lactate dehydrogenase [Enzymatic activity/volume] in Synovial fluid by Lactate to pyruvate reaction</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2007-3.html\">2007-3</a></td><td>Cancer Ag 15-3 [Presence] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/29153-4.html\">29153-4</a></td><td>Cancer Ag 15-3 [Units/volume] in Body fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/50776-4.html\">50776-4</a></td><td>Cancer Ag 15-3 [Units/volume] in Cerebral spinal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/50777-2.html\">50777-2</a></td><td>Cancer Ag 15-3 [Units/volume] in Pericardial fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/50778-0.html\">50778-0</a></td><td>Cancer Ag 15-3 [Units/volume] in Peritoneal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/6875-9.html\">6875-9</a></td><td>Cancer Ag 15-3 [Units/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/83083-6.html\">83083-6</a></td><td>Cancer Ag 15-3 [Units/volume] in Serum or Plasma by Immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/97749-6.html\">97749-6</a></td><td>Cancer Ag 15-3 [Units/volume] in Aspirate</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2011-5.html\">2011-5</a></td><td>Cancer Ag 242 [Presence] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/17842-6.html\">17842-6</a></td><td>Cancer Ag 27-29 [Units/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19187-4.html\">19187-4</a></td><td>Cancer Ag 27-29 [Units/volume] in Pleural fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2012-3.html\">2012-3</a></td><td>Cancer Ag 27-29 [Presence] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/50782-2.html\">50782-2</a></td><td>Cancer Ag 27-29 [Units/volume] in Cerebral spinal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2013-1.html\">2013-1</a></td><td>Cancer Ag 50 [Presence] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/34256-8.html\">34256-8</a></td><td>Cancer Ag 50 [Units/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19189-0.html\">19189-0</a></td><td>Cancer Ag 549 [Units/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19190-8.html\">19190-8</a></td><td>Cancer Ag 549 [Units/volume] in Pleural fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2014-9.html\">2014-9</a></td><td>Cancer Ag 549 [Presence] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/17843-4.html\">17843-4</a></td><td>Cancer Ag 72-4 [Units/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19164-3.html\">19164-3</a></td><td>Cancer Ag 72-4 [Units/volume] in Pleural fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2015-6.html\">2015-6</a></td><td>Cancer Ag 72-4 [Presence] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/34161-0.html\">34161-0</a></td><td>Cancer Ag 72-4 [Units/volume] in Body fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/47012-0.html\">47012-0</a></td><td>Cancer Ag 72-4 [Presence] in Tissue by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/68924-0.html\">68924-0</a></td><td>Cancer Ag 72-4 [Units/volume] in Peritoneal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/68925-7.html\">68925-7</a></td><td>Cancer Ag 72-4 [Units/volume] in Cerebral spinal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/68926-5.html\">68926-5</a></td><td>Cancer Ag 72-4 [Units/volume] in Pericardial fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2506-4.html\">2506-4</a></td><td>Isocitrate dehydrogenase [Enzymatic activity/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/72508-5.html\">72508-5</a></td><td>UGT1A1 gene c.A(TA)7TAA(*28) [Presence] in Blood or Tissue by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/21015-3.html\">21015-3</a></td><td>CD33 cells [#/volume] in Blood</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/74837-6.html\">74837-6</a></td><td>CD20 cells [#/volume] in Specimen</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/9558-8.html\">9558-8</a></td><td>CD20 cells [#/volume] in Blood</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/10508-0.html\">10508-0</a></td><td>Prostate specific Ag [Presence] in Tissue by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19195-7.html\">19195-7</a></td><td>Prostate specific Ag [Units/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19197-3.html\">19197-3</a></td><td>Prostate specific Ag [Moles/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19198-1.html\">19198-1</a></td><td>Prostate specific Ag [Units/volume] in Semen</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19199-9.html\">19199-9</a></td><td>Prostate specific Ag [Mass/volume] in Semen</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19200-5.html\">19200-5</a></td><td>Prostate specific Ag [Moles/volume] in Semen</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2857-1.html\">2857-1</a></td><td>Prostate specific Ag [Mass/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/34611-4.html\">34611-4</a></td><td>Prostate specific Ag [Mass/volume] in Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/35741-8.html\">35741-8</a></td><td>Prostate specific Ag [Mass/volume] in Serum or Plasma by Detection limit &lt;= 0.01 ng/mL</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/47738-0.html\">47738-0</a></td><td>Prostate specific Ag [Mass/volume] in Body fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/59221-2.html\">59221-2</a></td><td>Prostate specific Ag [Mass/volume] in Pleural fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/59223-8.html\">59223-8</a></td><td>Prostate specific Ag [Mass/volume] in Peritoneal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/59230-3.html\">59230-3</a></td><td>Prostate specific Ag [Mass/volume] in Cerebral spinal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/83112-3.html\">83112-3</a></td><td>Prostate specific Ag [Mass/volume] in Serum or Plasma by Immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/13127-6.html\">13127-6</a></td><td>Cancer Ag DM/70K [Units/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/13659-8.html\">13659-8</a></td><td>Epidermal growth factor receptor [Mass/mass] in Tissue</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/14050-9.html\">14050-9</a></td><td>Epidermal growth factor receptor [Moles/mass] in Tissue</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/21013-8.html\">21013-8</a></td><td>CD22 cells [#/volume] in Blood</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/14130-9.html\">14130-9</a></td><td>Estrogen receptor [Moles/mass] in Tissue</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/16112-5.html\">16112-5</a></td><td>Estrogen receptor [Interpretation] in Tissue</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78205-2.html\">78205-2</a></td><td>ALK gene rearrangements [Presence] in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78210-2.html\">78210-2</a></td><td>ALK gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/91141-2.html\">91141-2</a></td><td>TPMT activity in RBC by production of 6-MMP</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/91142-0.html\">91142-0</a></td><td>TPMT activity in RBC by production of 6-MMP riboside</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/91143-8.html\">91143-8</a></td><td>TPMT activity in RBC by production of 6-MTG riboside</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/83059-6.html\">83059-6</a></td><td>KRAS gene [VCF] in Cancer specimen by Sequencing</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/80717-2.html\">80717-2</a></td><td>B-cell CD27 and IgD subsets panel - Blood</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/85299-6.html\">85299-6</a></td><td>BRAF V600E mutant protein [Presence] in Cancer specimen by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/32996-1.html\">32996-1</a></td><td>HER2 [Mass/volume] in Serum</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/42914-2.html\">42914-2</a></td><td>HER2 [Mass/volume] in Serum by Immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/48676-1.html\">48676-1</a></td><td>HER2 [Interpretation] in Tissue</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51981-9.html\">51981-9</a></td><td>HER2 [Presence] in Serum by Immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/72382-5.html\">72382-5</a></td><td>HER2 [Units/volume] in Tissue by Immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/72383-3.html\">72383-3</a></td><td>HER2 [Presence] in Tissue by Immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/85319-2.html\">85319-2</a></td><td>HER2 [Presence] in Breast cancer specimen by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/28078-4.html\">28078-4</a></td><td>Bladder tumor Ag [Presence] in Urine by Immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/28551-0.html\">28551-0</a></td><td>Bladder tumor Ag [Units/volume] in Urine by Immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/31729-7.html\">31729-7</a></td><td>Bladder tumor Ag [Presence] in Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/31730-5.html\">31730-5</a></td><td>Bladder tumor Ag [Units/volume] in Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/80386-6.html\">80386-6</a></td><td>Bladder tumor Ag [Presence] in Urine by Rapid immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/31134-0.html\">31134-0</a></td><td>Nuclear matrix protein 22 [Units/volume] in Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/50666-7.html\">50666-7</a></td><td>Nuclear matrix protein 22 [Presence] in Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/34444-0.html\">34444-0</a></td><td>Acarboxyprothrombin [Mass/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/93768-0.html\">93768-0</a></td><td>Acarboxyprothrombin [Units/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/41292-4.html\">41292-4</a></td><td>Soluble mesothelin related proteins [Moles/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/43368-0.html\">43368-0</a></td><td>Microsatellite instability [Identifier] in Tissue by Molecular genetics method Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/62862-8.html\">62862-8</a></td><td>Microsatellite instability [Presence] in Tissue by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/81695-9.html\">81695-9</a></td><td>Microsatellite instability [Interpretation] in Cancer specimen Qualitative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/43399-5.html\">43399-5</a></td><td>JAK2 gene p.Val617Phe [Presence] in Blood or Tissue by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/72333-8.html\">72333-8</a></td><td>JAK2 gene p.Val617Phe [Presence] in Bone marrow by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/31150-6.html\">31150-6</a></td><td>ERBB2 gene duplication [Presence] in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/48674-6.html\">48674-6</a></td><td>Genetic diseases [Identifier] in Blood or Tissue by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/48684-5.html\">48684-5</a></td><td>X and Y chromosome [Interpretation] in Blood or Marrow by FISH--post bone marrow transplant</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/48730-6.html\">48730-6</a></td><td>X linked heterotaxy [Identifier] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/49028-4.html\">49028-4</a></td><td>Microdeletion syndromes [Identifier] in Blood or Tissue by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/49039-1.html\">49039-1</a></td><td>Subtelomere analysis [Identifier] in Blood or Tissue by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/49040-9.html\">49040-9</a></td><td>Subtelomere analysis [Interpretation] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/49063-1.html\">49063-1</a></td><td>Microdeletion syndromes in Specimen by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/49683-6.html\">49683-6</a></td><td>ERBB2 gene copy number/Chromosome 17 copy number in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/50020-7.html\">50020-7</a></td><td>Microdeletion syndromes in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/50659-2.html\">50659-2</a></td><td>Chromosome analysis.interphase [Interpretation] in Bone marrow by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/50684-0.html\">50684-0</a></td><td>Chromosome analysis.interphase [Interpretation] in Blood by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51867-0.html\">51867-0</a></td><td>t(9;22)(q34.1;q11)(ABL1,BCR) fusion transcript in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/53628-4.html\">53628-4</a></td><td>20q chromosome deletion [Identifier] in Blood or Tissue by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/55192-9.html\">55192-9</a></td><td>Chromosome analysis.interphase [Interpretation] in Amniotic fluid by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/55193-7.html\">55193-7</a></td><td>Chromosome analysis.interphase [Interpretation] in Chorionic villus sample by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/56030-0.html\">56030-0</a></td><td>Karyotype [Identifier] in Urine by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/56144-9.html\">56144-9</a></td><td>CHIC2 gene 4q12 deletion in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/57038-2.html\">57038-2</a></td><td>Chromosome 12 aneuploidy in Amniotic fluid or Chorionic villus sample by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/57317-0.html\">57317-0</a></td><td>Chromosome 13+18+21+X+Y aneuploidy in Amniotic fluid or Chorionic villus sample by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/57318-8.html\">57318-8</a></td><td>Chromosome 13+18+21+X+Y aneuploidy in Blood or Tissue by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/57453-3.html\">57453-3</a></td><td>Chromosome 18 aneuploidy in Amniotic fluid or Chorionic villus sample by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/57454-1.html\">57454-1</a></td><td>Chromosome 13 aneuploidy in Amniotic fluid or Chorionic villus sample by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/57802-1.html\">57802-1</a></td><td>Chromosome analysis.interphase [Interpretation] in Blood or Marrow by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/57906-0.html\">57906-0</a></td><td>9p21 chromosome deletion [Identifier] in Blood or Tissue by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/59050-5.html\">59050-5</a></td><td>Chromosome analysis.interphase [Interpretation] in Specimen by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/59267-5.html\">59267-5</a></td><td>Karyotype [Identifier] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/62344-7.html\">62344-7</a></td><td>Chromosome analysis.metaphase panel - Blood by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/62345-4.html\">62345-4</a></td><td>Chromosome analysis.interphase panel - Blood by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/62346-2.html\">62346-2</a></td><td>Chromosome analysis.interphase panel - Amniotic fluid by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/62347-0.html\">62347-0</a></td><td>Chromosome analysis.prenatal panel by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/62354-6.html\">62354-6</a></td><td>Chromosome analysis.metaphase panel - Amniotic fluid by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/62367-8.html\">62367-8</a></td><td>Chromosome analysis panel by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/63068-1.html\">63068-1</a></td><td>TOP2A gene copy number/Chromosome 17 copy number in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/63070-7.html\">63070-7</a></td><td>TOP2A gene 17q21-22 deletion and duplication mutation analysis [Presence] in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/66950-7.html\">66950-7</a></td><td>MALT1 18q21 gene rearrangements in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/72652-1.html\">72652-1</a></td><td>Subtelomere analysis.long arm [Interpretation] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/72653-9.html\">72653-9</a></td><td>Subtelomere analysis.short arm [Interpretation] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/72654-7.html\">72654-7</a></td><td>SNRPN gene 15q11 deletion and duplication mutation analysis [Identifier] in Blood or Tissue by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/72725-5.html\">72725-5</a></td><td>t(11;14)(q13.2;q32)(MYEOV,IGH) fusion transcript [Identifier] in Blood or Tissue by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/72726-3.html\">72726-3</a></td><td>t(4;14)(p16;q32)(FGFR3,IGH) fusion transcript [Identifier] in Blood or Tissue by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/72728-9.html\">72728-9</a></td><td>Del(13)(q14) [Identifier] in Blood or Tissue by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/72824-6.html\">72824-6</a></td><td>Del(17)(p13) [Identifier] in Blood or Tissue by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/72827-9.html\">72827-9</a></td><td>dic(9;20)(p11-13;q11)(wcp9+,wcp20+) [Identifier] in Blood or Tissue by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/73558-9.html\">73558-9</a></td><td>Staphylococcus aureus and Staphylococcus sp.coagulase negative rRNA [Identifier] by FISH in Positive blood culture</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/73749-4.html\">73749-4</a></td><td>4p16.3 chromosome deletion [Identifier] in Blood or Tissue by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/73750-2.html\">73750-2</a></td><td>RAI1 gene 17p11.2 deletion and duplication mutation analysis [Identifier] in Blood or Tissue by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/73751-0.html\">73751-0</a></td><td>5p15.2 (5p-) chromosome deletion [Identifier] in Blood or Tissue by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/74034-0.html\">74034-0</a></td><td>MAML2 11q21 gene rearrangements in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/74860-8.html\">74860-8</a></td><td>ERBB2 gene copy number/nucleus in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/74861-6.html\">74861-6</a></td><td>Chromosome 17 copy number/nucleus in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/74885-5.html\">74885-5</a></td><td>ERBB2 gene (HER2) duplication associated observations panel - Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/76065-2.html\">76065-2</a></td><td>6p25 and 6q23 and 11q and 8q24 and 9p21 chromosome partial aneuploidy in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/77030-5.html\">77030-5</a></td><td>t(1;19)(q23.3;p13.3)(PBX1,TCF3) fusion transcript in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/77031-3.html\">77031-3</a></td><td>t(15;17)(q24.1;q21.1)(PML,RARA) fusion transcript in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/77032-1.html\">77032-1</a></td><td>t(8;14)(q24;q32)(MYC,IGH) fusion transcript in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/77033-9.html\">77033-9</a></td><td>t(14;16)(q32;q23)(IGH,MAF) fusion transcript in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/77034-7.html\">77034-7</a></td><td>inv(16)(p13.1;q22.1)(MYH11,CBFB) fusion transcript in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/77035-4.html\">77035-4</a></td><td>t(14;18)(q32;q21)(IGH,MALT1) fusion transcript in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/77036-2.html\">77036-2</a></td><td>t(11;18)(q21;q21)(BIRC3,MALT1) fusion transcript in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/77037-0.html\">77037-0</a></td><td>t(11;14)(q13;q32)(CCND1,IGH) fusion transcript in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/77038-8.html\">77038-8</a></td><td>t(14;18)(q32;q21.3)(IGH,BCL2) fusion transcript in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/77039-6.html\">77039-6</a></td><td>t(12;21)(p13;q22.3)(ETV6,RUNX1) fusion transcript in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/77040-4.html\">77040-4</a></td><td>t(8;21)(q22;q22.3)(RUNX1T1,RUNX1) fusion transcript in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/77041-2.html\">77041-2</a></td><td>inv(3)(q21;q26.2)+t(3;3)(q21;q26.2)(PSMD2,MECOM) fusion transcript in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/77042-0.html\">77042-0</a></td><td>t(6;9)(p22;q34)(DEK,NUP214) fusion transcript in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78201-1.html\">78201-1</a></td><td>4q12 chromosome region rearrangements [Identifier] in Blood or Tissue by FISH Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78202-9.html\">78202-9</a></td><td>9q34 chromosome region deletion [Presence] in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78203-7.html\">78203-7</a></td><td>BCL6 gene rearrangements [Presence] in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78204-5.html\">78204-5</a></td><td>CCND1 gene duplication [Presence] in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78206-0.html\">78206-0</a></td><td>4q12 chromosome region rearrangements [Interpretation] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78207-8.html\">78207-8</a></td><td>9q34 chromosome region deletion [Interpretation] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78208-6.html\">78208-6</a></td><td>BCL6 gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78209-4.html\">78209-4</a></td><td>CCND1 gene duplication [Interpretation] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78211-0.html\">78211-0</a></td><td>Cells.4q12 chromosome region rearrangements/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78212-8.html\">78212-8</a></td><td>Cells.9q34 chromosome region deletion/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78213-6.html\">78213-6</a></td><td>Cells.BCL6 gene rearrangements/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78214-4.html\">78214-4</a></td><td>Cells.CCND1 gene duplication/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78215-1.html\">78215-1</a></td><td>MYC gene rearrangements [Presence] in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78216-9.html\">78216-9</a></td><td>TRA+TRD gene rearrangements [Presence] in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78217-7.html\">78217-7</a></td><td>RARA gene rearrangements [Presence] in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78218-5.html\">78218-5</a></td><td>BCL2 gene rearrangements [Presence] in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78219-3.html\">78219-3</a></td><td>MLL gene rearrangements [Presence] in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78220-1.html\">78220-1</a></td><td>PDGFRB gene rearrangements [Presence] in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78221-9.html\">78221-9</a></td><td>IGH gene rearrangements [Presence] in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78222-7.html\">78222-7</a></td><td>MYC gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78223-5.html\">78223-5</a></td><td>TRA+TRD gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78224-3.html\">78224-3</a></td><td>RARA gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78225-0.html\">78225-0</a></td><td>BCL2 gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78226-8.html\">78226-8</a></td><td>MLL gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78227-6.html\">78227-6</a></td><td>PDGFRB gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78228-4.html\">78228-4</a></td><td>IGH gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78229-2.html\">78229-2</a></td><td>Cells.MYC gene rearrangements/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78230-0.html\">78230-0</a></td><td>Cells.RARA gene rearrangements/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78231-8.html\">78231-8</a></td><td>Cells.TRA+TRD gene rearrangements/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78232-6.html\">78232-6</a></td><td>Cells.BCL2 gene rearrangements/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78233-4.html\">78233-4</a></td><td>Cells.ALK gene rearrangements/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78234-2.html\">78234-2</a></td><td>Cells.MLL gene rearrangements/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78235-9.html\">78235-9</a></td><td>Cells.PDGFRB gene rearrangements/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78236-7.html\">78236-7</a></td><td>Cells.IGH gene rearrangements/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78237-5.html\">78237-5</a></td><td>Chromosome 8 copy number/nucleus in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78238-3.html\">78238-3</a></td><td>Chromosome 3 copy number/nucleus in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78245-8.html\">78245-8</a></td><td>MYB gene deletion [Presence] in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78342-3.html\">78342-3</a></td><td>MYB gene deletion [Interpretation] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78343-1.html\">78343-1</a></td><td>Cells.MYB gene deletion/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78915-6.html\">78915-6</a></td><td>FGFR1 gene rearrangements [Presence] in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78916-4.html\">78916-4</a></td><td>FGFR1 gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/78917-2.html\">78917-2</a></td><td>Cells.FGFR1 gene rearrangements/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/79206-9.html\">79206-9</a></td><td>inv(2)(p21;p23)(EML4,ALK) fusion transcript [Presence] in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/81710-6.html\">81710-6</a></td><td>PTEN gene [Presence] in Cancer specimen by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/81746-0.html\">81746-0</a></td><td>Chromosome region 17p13.1 deletion in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/81747-8.html\">81747-8</a></td><td>Chromosome region 6q22 rearrangements in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/81748-6.html\">81748-6</a></td><td>Chromosome region Yp11.3 deletion AndOr rearrangement in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/81749-4.html\">81749-4</a></td><td>Chromosome region 13q14 deletion in Bone marrow by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/81751-0.html\">81751-0</a></td><td>Chromosome 17p13.1 deletion and 14q32 rearrangements in Bone marrow by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/81752-8.html\">81752-8</a></td><td>Chromosome region 1q21 duplication in Bone marrow by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82238-7.html\">82238-7</a></td><td>Chromosome region 15q11-13 deletion and duplication mutation analysis in Amniotic fluid or Chorionic villus sample by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82239-5.html\">82239-5</a></td><td>Chromosome region 16p13.3 deletion in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82240-3.html\">82240-3</a></td><td>Chromosome region 16p13.3 deletion in Amniotic fluid or Chorionic villus sample by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82241-1.html\">82241-1</a></td><td>Chromosome region 17p11.2 deletion in Amniotic fluid or Chorionic villus sample by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82242-9.html\">82242-9</a></td><td>Chromosome region 17p13.3 deletion in Amniotic fluid or Chorionic villus sample by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82243-7.html\">82243-7</a></td><td>Chromosome region 17p13.3 deletion in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82244-5.html\">82244-5</a></td><td>Chromosome region 1p36 deletion in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82245-2.html\">82245-2</a></td><td>Chromosome region 22q11.2 deletion and duplication mutation analysis in Amniotic fluid or Chorionic villus sample by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82246-0.html\">82246-0</a></td><td>Chromosome region 22q11.2 deletion and duplication mutation analysis in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82247-8.html\">82247-8</a></td><td>Chromosome region 7q11.23 deletion in Amniotic fluid or Chorionic villus sample by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82248-6.html\">82248-6</a></td><td>Chromosome region 7q11.23 deletion in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82249-4.html\">82249-4</a></td><td>Chromosome region 8q23.3-24.13 deletion in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82250-2.html\">82250-2</a></td><td>Chromosome region 1p subtelomere and 1p36 deletion and 1q25 rearrangement in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82251-0.html\">82251-0</a></td><td>Chromosome 3 and 7 and 17 aneuploidy and chromosome region 9p21 deletion in Urine by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82253-6.html\">82253-6</a></td><td>JAG1 gene deletion in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82256-9.html\">82256-9</a></td><td>Chromosome 12 trisomy and chromosome region 11q22.3 and 13q14 and 17p13.1 deletion in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82257-7.html\">82257-7</a></td><td>SRY gene deletion in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82258-5.html\">82258-5</a></td><td>Subtelomere analysis in Bone marrow by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82295-7.html\">82295-7</a></td><td>Chromosome region Xp22.33 AndOr Yp11.32 deletion and duplication mutation analysis in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82597-6.html\">82597-6</a></td><td>Chromosome painting analysis in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/84912-5.html\">84912-5</a></td><td>Cells.chromosome region 5q31 deletion/Cells counted in Bone marrow by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/84913-3.html\">84913-3</a></td><td>Cells.chromosome 12 trisomy/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/84914-1.html\">84914-1</a></td><td>Cells.chromosome region 13q14 deletion/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/84915-8.html\">84915-8</a></td><td>Cells.chromosome region 11q22.3 deletion/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/84916-6.html\">84916-6</a></td><td>Cells.chromosome region 17p13.1 deletion/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/84917-4.html\">84917-4</a></td><td>Chromosome Y aneuploidy [Presence] in Amniotic fluid or Chorionic villus sample by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/84918-2.html\">84918-2</a></td><td>Chromosome X aneuploidy [Presence] in Amniotic fluid or Chorionic villus sample by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/84919-0.html\">84919-0</a></td><td>Chromosome 21 aneuploidy [Presence] in Amniotic fluid or Chorionic villus sample by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/84920-8.html\">84920-8</a></td><td>Cells.chromosome region 5q31 deletion/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/84921-6.html\">84921-6</a></td><td>Cells.chromosome region 7q31 deletion/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/84922-4.html\">84922-4</a></td><td>Cells.chromosome 7 monosomy/Cells counted in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/85318-4.html\">85318-4</a></td><td>ERBB2 gene duplication [Presence] in Breast cancer specimen by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/86239-1.html\">86239-1</a></td><td>Cells.chromosome 3 monosomy/Cells counted in Cancer specimen by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/87436-2.html\">87436-2</a></td><td>Chromosome X and Y aneuploidy in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/90043-1.html\">90043-1</a></td><td>t(14;20)(q32;q12)(IGH,MAFB) fusion transcript in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/90926-7.html\">90926-7</a></td><td>MET gene amplification in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/90927-5.html\">90927-5</a></td><td>RET gene rearrangements in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/92905-9.html\">92905-9</a></td><td>Chromosome 7 copy number/nucleus in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/92906-7.html\">92906-7</a></td><td>MET gene copy number/nucleus in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/92907-5.html\">92907-5</a></td><td>MET gene copy number/Chromosome 7 copy number in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/93796-1.html\">93796-1</a></td><td>MYCN gene amplification in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/93797-9.html\">93797-9</a></td><td>MYCN gene copy number/Chromosome 2 copy number in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/93798-7.html\">93798-7</a></td><td>MYCN gene copy number/nucleus in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/93799-5.html\">93799-5</a></td><td>Chromosome 2 copy number/nucleus in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/93800-1.html\">93800-1</a></td><td>1p/1q chromosome deletion [# Ratio] in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/93801-9.html\">93801-9</a></td><td>Chromosome 1 polysomy [Presence] in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/93802-7.html\">93802-7</a></td><td>19q/19p chromosome deletion [# Ratio] in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/93803-5.html\">93803-5</a></td><td>Chromosome 19 polysomy [Presence] in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/93804-3.html\">93804-3</a></td><td>Chromosome 12 copy number/nucleus in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/93805-0.html\">93805-0</a></td><td>MDM2 gene copy number/nucleus in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/93806-8.html\">93806-8</a></td><td>EWSR1 gene rearrangements in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/93807-6.html\">93807-6</a></td><td>FOXO1 gene rearrangements in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/93808-4.html\">93808-4</a></td><td>MDM2 gene amplification in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/93809-2.html\">93809-2</a></td><td>MDM2 gene copy number/Chromosome 12 copy number in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/93810-0.html\">93810-0</a></td><td>SS18 gene rearrangements in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/94338-1.html\">94338-1</a></td><td>Chromosome 13+15+16+18+21+22+X+Y aneuploidy in Products of Conception by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/95069-1.html\">95069-1</a></td><td>Chromosome 1q and 9 and 11 and 15 aneuploidy and 13q deletion in Bone marrow by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/95070-9.html\">95070-9</a></td><td>Chromosome 9 and 11 and 15 aneuploidy in Bone marrow by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/95071-7.html\">95071-7</a></td><td>Chromosome region 14q32 rearrangements in Bone marrow by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/95551-8.html\">95551-8</a></td><td>Chromosome region 17p11.2 deletion in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/95552-6.html\">95552-6</a></td><td>4p16.3 chromosome deletion in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/95553-4.html\">95553-4</a></td><td>5p15.2 (5p-) chromosome deletion [Identifier] in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/95779-5.html\">95779-5</a></td><td>TFE3 gene rearrangements in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/95780-3.html\">95780-3</a></td><td>TFEB gene rearrangements in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/95783-7.html\">95783-7</a></td><td>ETV6 gene rearrangements in Blood or Marrow by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/95784-5.html\">95784-5</a></td><td>FGFR2 gene rearrangements in Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/96494-0.html\">96494-0</a></td><td>ABL1 and ABL2 and PDGFRB gene rearrangements in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/96495-7.html\">96495-7</a></td><td>ABL2 gene rearrangements in Blood or Tissue by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/96893-3.html\">96893-3</a></td><td>ERBB2 gene duplication in Tumor by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/98014-4.html\">98014-4</a></td><td>Plasma cell proliferation analysis in Bone marrow by FISH</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/49490-6.html\">49490-6</a></td><td>BCR-ABL1 b2a2 fusion protein [Presence] in Blood or Tissue by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/55180-4.html\">55180-4</a></td><td>Human epididymis protein 4 [Moles/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/96044-3.html\">96044-3</a></td><td>Human epididymis protein 4 [Mass/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/60588-1.html\">60588-1</a></td><td>t(15;17)(q24.1;q21.1)(PML,RARA) bcr2 fusion transcript [Presence] in Blood or Tissue by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/72211-6.html\">72211-6</a></td><td>t(15;17)(q24.1;q21.1)(PML,RARA) bcr2 fusion transcript/control transcript [# Ratio] in Bone marrow by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/72215-7.html\">72215-7</a></td><td>t(15;17)(q24.1;q21.1)(PML,RARA) bcr2 fusion transcript/control transcript [# Ratio] in Blood or Tissue by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/10432-3.html\">10432-3</a></td><td>CD30 Ag [Presence] in Tissue by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/10560-1.html\">10560-1</a></td><td>Carcinoembryonic Ag [Units/volume] in Semen</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/12515-3.html\">12515-3</a></td><td>Carcinoembryonic Ag [Mass/volume] in Body fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19166-8.html\">19166-8</a></td><td>Carcinoembryonic Ag [Units/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19167-6.html\">19167-6</a></td><td>Carcinoembryonic Ag [Moles/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19168-4.html\">19168-4</a></td><td>Carcinoembryonic Ag [Units/volume] in Pleural fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19169-2.html\">19169-2</a></td><td>Carcinoembryonic Ag [Mass/volume] in Pleural fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/19170-0.html\">19170-0</a></td><td>Carcinoembryonic Ag [Moles/volume] in Pleural fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2037-0.html\">2037-0</a></td><td>Carcinoembryonic Ag [Mass/volume] in Cerebral spinal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2038-8.html\">2038-8</a></td><td>Carcinoembryonic Ag [Mass/volume] in Semen</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/2039-6.html\">2039-6</a></td><td>Carcinoembryonic Ag [Mass/volume] in Serum or Plasma</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/40621-5.html\">40621-5</a></td><td>Carcinoembryonic Ag [Mass/volume] in Pericardial fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/40622-3.html\">40622-3</a></td><td>Carcinoembryonic Ag [Mass/volume] in Peritoneal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/83085-1.html\">83085-1</a></td><td>Carcinoembryonic Ag [Mass/volume] in Serum or Plasma by Immunoassay</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/14230-7.html\">14230-7</a></td><td>Cells.progesterone receptor/100 cells in Tissue by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/40557-1.html\">40557-1</a></td><td>Progesterone receptor Ag [Presence] in Tissue by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/85325-9.html\">85325-9</a></td><td>Cells.progesterone receptor/100 cells in Breast cancer specimen by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/85331-7.html\">85331-7</a></td><td>Progesterone receptor fluorescence intensity [Type] in Breast cancer specimen by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/85339-0.html\">85339-0</a></td><td>Progesterone receptor Ag [Presence] in Breast cancer specimen by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/13485-8.html\">13485-8</a></td><td>Beta-2-Microglobulin/Creatinine [Mass Ratio] in Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/39773-7.html\">39773-7</a></td><td>Beta-2-Microglobulin/Creatinine [Molar ratio] in Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/44303-6.html\">44303-6</a></td><td>Beta-2-Microglobulin/Creatinine [Mass Ratio] in 24 hour Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/56786-7.html\">56786-7</a></td><td>Beta-2-Microglobulin.tumor marker [Mass/volume] in Serum</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/59177-6.html\">59177-6</a></td><td>Beta-2-Microglobulin/Creatinine [Ratio] in Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/87708-4.html\">87708-4</a></td><td>Beta-2-Microglobulin [Mass/volume] in Serum or Plasma --post dialysis</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/93729-2.html\">93729-2</a></td><td>Beta-2-Microglobulin/Creatinine [Ratio] in 24 hour Urine</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/14967-4.html\">14967-4</a></td><td>CD33 Abnormal blood cells/Abnormal blood cells.total in Blood</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/20601-1.html\">20601-1</a></td><td>CD33 cells/100 cells in Unspecified specimen</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51155-0.html\">51155-0</a></td><td>CD33 blasts/100 blasts in Bone marrow</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51156-8.html\">51156-8</a></td><td>CD33 blasts/100 blasts in Unspecified specimen</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51157-6.html\">51157-6</a></td><td>CD33 blasts [Units/volume] in Bone marrow</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51158-4.html\">51158-4</a></td><td>CD33 blasts [Units/volume] in Blood</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51159-2.html\">51159-2</a></td><td>CD33 blasts [Units/volume] in Unspecified specimen</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51291-3.html\">51291-3</a></td><td>CD33 cells/100 cells in Tissue</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51292-1.html\">51292-1</a></td><td>CD33 cells/100 cells in Cerebral spinal fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51293-9.html\">51293-9</a></td><td>CD33 cells/100 cells in Bone marrow</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51294-7.html\">51294-7</a></td><td>CD33 cells/100 cells in Body fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/8102-6.html\">8102-6</a></td><td>CD33 cells/100 cells in Blood</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/10438-0.html\">10438-0</a></td><td>CD20 Ag [Presence] in Tissue by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/13842-0.html\">13842-0</a></td><td>CD20 blasts/100 blasts in Blood</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/14966-6.html\">14966-6</a></td><td>CD20 Abnormal blood cells/Abnormal blood cells.total in Blood</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/20595-5.html\">20595-5</a></td><td>CD20 cells/100 cells in Unspecified specimen</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51115-4.html\">51115-4</a></td><td>CD20 blasts/100 blasts in Bone marrow</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51116-2.html\">51116-2</a></td><td>CD20 blasts/100 blasts in Unspecified specimen</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/57418-6.html\">57418-6</a></td><td>CD20 cells/100 cells in Body fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/8119-0.html\">8119-0</a></td><td>CD20 cells/100 cells in Blood</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/29596-4.html\">29596-4</a></td><td>CD25 Ag [Presence] in Tissue by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/32581-1.html\">32581-1</a></td><td>Epidermal growth factor receptor Ag [Presence] in Tissue by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/39004-7.html\">39004-7</a></td><td>Epidermal growth factor receptor Ag [Presence] in Tissue</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/42782-3.html\">42782-3</a></td><td>Epidermal growth factor receptor.phosphorylated Ag [Presence] in Tissue by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/14017-8.html\">14017-8</a></td><td>CD22 cells/100 cells in Blood</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/20596-3.html\">20596-3</a></td><td>CD22 cells/100 cells in Unspecified specimen</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/42875-5.html\">42875-5</a></td><td>CD22 cells/100 cells in Body fluid</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51124-6.html\">51124-6</a></td><td>CD22 blasts/100 blasts in Bone marrow</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51125-3.html\">51125-3</a></td><td>CD22 blasts/100 blasts in Blood</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51126-1.html\">51126-1</a></td><td>CD22 blasts/100 blasts in Unspecified specimen</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51127-9.html\">51127-9</a></td><td>CD22 blasts [Units/volume] in Bone marrow</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51128-7.html\">51128-7</a></td><td>CD22 blasts [Units/volume] in Blood</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51129-5.html\">51129-5</a></td><td>CD22 blasts [Units/volume] in Unspecified specimen</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/14228-1.html\">14228-1</a></td><td>Cells.estrogen receptor/100 cells in Tissue by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/40556-3.html\">40556-3</a></td><td>Estrogen receptor Ag [Presence] in Tissue by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/85310-1.html\">85310-1</a></td><td>Estrogen receptor fluorescence intensity [Type] in Breast cancer specimen by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/85329-1.html\">85329-1</a></td><td>Cells.estrogen receptor/100 cells in Breast cancer specimen by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/85337-4.html\">85337-4</a></td><td>Estrogen receptor Ag [Presence] in Breast cancer specimen by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/21636-6.html\">21636-6</a></td><td>BRCA1 gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/21637-4.html\">21637-4</a></td><td>BRCA1 gene.c.185 del AG [presence] in Blood or Tissue by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/21638-2.html\">21638-2</a></td><td>BRCA1 gene c.5382insC [Presence] in Blood or Tissue by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/21639-0.html\">21639-0</a></td><td>BRCA1 gene mutations tested for in Blood or Tissue by Molecular genetics method Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/79207-7.html\">79207-7</a></td><td>BRCA1 gene mutation analysis limited to known familial mutations in Blood or Tissue by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/21702-6.html\">21702-6</a></td><td>KRAS gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/21703-4.html\">21703-4</a></td><td>KRAS gene mutations tested for in Blood or Tissue by Molecular genetics method Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/53620-1.html\">53620-1</a></td><td>KRAS gene mutations found [Identifier] in Bone marrow by Molecular genetics method Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/75974-6.html\">75974-6</a></td><td>KRAS gene targeted mutation analysis in Blood or Tissue by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/81420-2.html\">81420-2</a></td><td>KRAS and NRAS gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/82535-6.html\">82535-6</a></td><td>KRAS gene full mutation analysis in Blood or Tissue by Sequencing</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/85509-8.html\">85509-8</a></td><td>KRAS gene mutations found [Identifier] in Colorectal cancer specimen by Molecular genetics method Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/40552-2.html\">40552-2</a></td><td>CD117 Ag [Presence] in Tissue by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51183-2.html\">51183-2</a></td><td>CD117 Ag [Presence] in Bone marrow by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51184-0.html\">51184-0</a></td><td>CD117 Ag [Presence] in Blood by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/51185-7.html\">51185-7</a></td><td>CD117 Ag [Presence] in Unspecified specimen by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/80706-5.html\">80706-5</a></td><td>CD27+IgD- cells/100 CD19+CD20+ cells in Blood</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/83052-1.html\">83052-1</a></td><td>PD-L1 by clone 22C3 [Presence] in Tissue by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/83053-9.html\">83053-9</a></td><td>Cells.programmed cell death ligand 1/100 viable tumor cells in Tissue by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/83054-7.html\">83054-7</a></td><td>PD-L1 by clone 22C3 [Interpretation] in Tissue by Immune stain Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/83055-4.html\">83055-4</a></td><td>PD-L1 by clone 28-8 [Presence] in Tissue by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/83056-2.html\">83056-2</a></td><td>PD-L1 by clone 28-8 [Interpretation] in Tissue by Immune stain Narrative</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/83057-0.html\">83057-0</a></td><td>PD-L1 by clone SP142 [Presence] in Tissue by Immune stain</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/85147-7.html\">85147-7</a></td><td>PD-L1 by clone 22C3 in Tissue by Immune stain Report</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/85148-5.html\">85148-5</a></td><td>PD-L1 by clone 28-8 in Tissue by Immune stain Report</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/85149-3.html\">85149-3</a></td><td>PD-L1 by clone SP142 in Tissue by Immune stain Report</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/21640-8.html\">21640-8</a></td><td>BRCA2 gene c.6174delT [Presence] in Blood or Tissue by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/38530-2.html\">38530-2</a></td><td>BRCA2 gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/38531-0.html\">38531-0</a></td><td>BRCA2 gene mutations tested for in Blood or Tissue by Molecular genetics method Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/79208-5.html\">79208-5</a></td><td>BRCA2 gene mutation analysis limited to known familial mutations in Blood or Tissue by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/45284-7.html\">45284-7</a></td><td>DPYD gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/47958-4.html\">47958-4</a></td><td>FLT3 gene targeted mutation analysis in Blood or Tissue by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/54447-8.html\">54447-8</a></td><td>FLT3 gene targeted mutation analysis in Bone marrow by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/72520-0.html\">72520-0</a></td><td>FLT3 gene p.Asp835+Ile836 [Presence] in Blood or Tissue by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/79210-1.html\">79210-1</a></td><td>FLT3 gene internal tandem duplication [Presence] in Blood or Tissue by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/85100-6.html\">85100-6</a></td><td>FLT3 gene internal tandem duplication [Presence] in Bone marrow by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/92843-2.html\">92843-2</a></td><td>FLT3 gene p.Asp835 mutations [Presence] in Blood or Tissue by Molecular genetics method</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/48972-4.html\">48972-4</a></td><td>FGFR2 gene+FGFR3 gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal</td></tr></table></li></ul></div>"
+  },
+  "url": "http://hl7.org/fhir/us/mcode/ValueSet/mcode-tumor-marker-test-vs",
+  "version": "2.0.0",
+  "name": "TumorMarkerTestVS",
+  "title": "Tumor Marker Test Value Set",
+  "status": "active",
+  "date": "2022-01-14T14:19:51+00:00",
+  "publisher": "HL7 International Clinical Interoperability Council",
+  "contact": [
+    {
+      "name": "HL7 International Clinical Interoperability Council",
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://www.hl7.org/Special/committees/cic"
+        },
+        {
+          "system": "email",
+          "value": "ciclist@lists.HL7.org"
+        }
+      ]
+    }
+  ],
+  "description": "Codes representing tests for tumor markers. This value set of LOINC codes is not comprehensive and can be extended. Other vocabularies can be used only if the test of interest is not covered by LOINC. Tumor marker tests differ from genetic tests in that they measure levels of protein or other substances produced downstream from RNA protein synthesis.",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "system": "urn:iso:std:iso:3166",
+          "code": "US",
+          "display": "United States of America"
+        }
+      ]
+    }
+  ],
+  "copyright": "This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
+  "compose": {
+    "include": [
+      {
+        "system": "http://loinc.org",
+        "concept": [
+          {
+            "code": "62320-7",
+            "display": "T-cell receptor excision circle [#/volume] in DBS by NAA with probe detection"
+          },
+          {
+            "code": "92006-6",
+            "display": "T-cell receptor excision circle [Cycle Threshold #] in DBS"
+          },
+          {
+            "code": "92007-4",
+            "display": "T-cell receptor excision circle [Z-score] in DBS"
+          },
+          {
+            "code": "92008-2",
+            "display": "T-cell receptor excision circle [Multiple of the median] in DBS"
+          },
+          {
+            "code": "69361-4",
+            "display": "PCA3 score in Urine by Molecular genetics method"
+          },
+          {
+            "code": "69362-2",
+            "display": "PCA3 score in Urine Qualitative by Molecular genetics method"
+          },
+          {
+            "code": "19163-5",
+            "display": "Cancer Ag 19-9 [Units/volume] in Pleural fluid"
+          },
+          {
+            "code": "2009-9",
+            "display": "Cancer Ag 19-9 [Presence] in Serum or Plasma"
+          },
+          {
+            "code": "24108-3",
+            "display": "Cancer Ag 19-9 [Units/volume] in Serum or Plasma"
+          },
+          {
+            "code": "26924-1",
+            "display": "Cancer Ag 19-9 [Units/volume] in Body fluid"
+          },
+          {
+            "code": "50779-8",
+            "display": "Cancer Ag 19-9 [Units/volume] in Cerebral spinal fluid"
+          },
+          {
+            "code": "50780-6",
+            "display": "Cancer Ag 19-9 [Units/volume] in Pericardial fluid"
+          },
+          {
+            "code": "50781-4",
+            "display": "Cancer Ag 19-9 [Units/volume] in Peritoneal fluid"
+          },
+          {
+            "code": "83084-4",
+            "display": "Cancer Ag 19-9 [Units/volume] in Serum or Plasma by Immunoassay"
+          },
+          {
+            "code": "97750-4",
+            "display": "Cancer Ag 19-9 [Units/volume] in Aspirate"
+          },
+          {
+            "code": "14041-8",
+            "display": "Choriogonadotropin.beta subunit [Units/volume] in Cerebral spinal fluid"
+          },
+          {
+            "code": "19174-2",
+            "display": "Choriogonadotropin.beta subunit [Units/volume] in Amniotic fluid"
+          },
+          {
+            "code": "19175-9",
+            "display": "Choriogonadotropin.beta subunit [Moles/volume] in Amniotic fluid"
+          },
+          {
+            "code": "20415-6",
+            "display": "Choriogonadotropin.beta subunit [Units/volume] in Serum or Plasma by Immunoassay (EIA) 3rd IS"
+          },
+          {
+            "code": "2111-3",
+            "display": "Choriogonadotropin.beta subunit [Moles/volume] in Serum or Plasma"
+          },
+          {
+            "code": "2113-9",
+            "display": "Choriogonadotropin.beta subunit [Mass/time] in 24 hour Urine"
+          },
+          {
+            "code": "2114-7",
+            "display": "Choriogonadotropin.beta subunit [Moles/volume] in Urine"
+          },
+          {
+            "code": "21198-7",
+            "display": "Choriogonadotropin.beta subunit [Units/volume] in Serum or Plasma"
+          },
+          {
+            "code": "29154-2",
+            "display": "Choriogonadotropin.beta subunit [Units/volume] in Body fluid"
+          },
+          {
+            "code": "43799-6",
+            "display": "Choriogonadotropin.beta subunit [Presence] in Specimen"
+          },
+          {
+            "code": "43800-2",
+            "display": "Choriogonadotropin.beta subunit [Presence] in Cerebral spinal fluid"
+          },
+          {
+            "code": "55868-4",
+            "display": "Choriogonadotropin.beta subunit [Multiple of the median] in Serum or Plasma"
+          },
+          {
+            "code": "55869-2",
+            "display": "Choriogonadotropin.beta subunit [Mass/volume] in Serum or Plasma"
+          },
+          {
+            "code": "56497-1",
+            "display": "Choriogonadotropin.beta subunit [Units] in 24 hour Urine"
+          },
+          {
+            "code": "66762-6",
+            "display": "Choriogonadotropin.beta subunit [Units/volume] in Pleural fluid"
+          },
+          {
+            "code": "66763-4",
+            "display": "Choriogonadotropin.beta subunit [Units/volume] in Peritoneal fluid"
+          },
+          {
+            "code": "10334-1",
+            "display": "Cancer Ag 125 [Units/volume] in Serum or Plasma"
+          },
+          {
+            "code": "11210-2",
+            "display": "Cancer Ag 125 [Units/volume] in Body fluid"
+          },
+          {
+            "code": "15156-3",
+            "display": "Cancer Ag 125 [Units/volume] in Body fluid by Dilution"
+          },
+          {
+            "code": "15157-1",
+            "display": "Cancer Ag 125 [Units/volume] in Serum or Plasma by Dilution"
+          },
+          {
+            "code": "19165-0",
+            "display": "Cancer Ag 125 [Units/volume] in Pleural fluid"
+          },
+          {
+            "code": "2006-5",
+            "display": "Cancer Ag 125 [Presence] in Serum or Plasma"
+          },
+          {
+            "code": "40618-1",
+            "display": "Cancer Ag 125 [Units/volume] in Peritoneal fluid"
+          },
+          {
+            "code": "48677-9",
+            "display": "Cancer Ag 125 [Presence] in Tissue by Immune stain"
+          },
+          {
+            "code": "50775-6",
+            "display": "Cancer Ag 125 [Units/volume] in Cerebral spinal fluid"
+          },
+          {
+            "code": "59040-6",
+            "display": "Cancer Ag 125 [Units/volume] in Peritoneal dialysis fluid"
+          },
+          {
+            "code": "68923-2",
+            "display": "Cancer Ag 125 [Units/volume] in Pericardial fluid"
+          },
+          {
+            "code": "83082-8",
+            "display": "Cancer Ag 125 [Units/volume] in Serum or Plasma by Immunoassay"
+          },
+          {
+            "code": "97743-9",
+            "display": "Cancer Ag 125 [Units/volume] in Aspirate"
+          },
+          {
+            "code": "15035-9",
+            "display": "Calcitonin [Moles/volume] in Serum or Plasma"
+          },
+          {
+            "code": "1992-7",
+            "display": "Calcitonin [Mass/volume] in Serum or Plasma"
+          },
+          {
+            "code": "47369-4",
+            "display": "Calcitonin [Mass/volume] in Body fluid"
+          },
+          {
+            "code": "75709-6",
+            "display": "Calcitonin [Mass/volume] in Lymph node fine needle aspirate"
+          },
+          {
+            "code": "25587-7",
+            "display": "Chromogranin A [Moles/volume] in Serum or Plasma"
+          },
+          {
+            "code": "30169-7",
+            "display": "Chromogranin A [Units/volume] in Serum or Plasma by Immunoassay"
+          },
+          {
+            "code": "53047-7",
+            "display": "Chromogranin A [Mass/volume] in Body fluid"
+          },
+          {
+            "code": "59220-4",
+            "display": "Chromogranin A [Units/volume] in Pleural fluid"
+          },
+          {
+            "code": "59226-1",
+            "display": "Chromogranin A [Units/volume] in Peritoneal fluid"
+          },
+          {
+            "code": "59227-9",
+            "display": "Chromogranin A [Units/volume] in Cerebral spinal fluid"
+          },
+          {
+            "code": "59241-0",
+            "display": "Chromogranin A [Units/volume] in Body fluid"
+          },
+          {
+            "code": "9811-1",
+            "display": "Chromogranin A [Mass/volume] in Serum or Plasma"
+          },
+          {
+            "code": "15060-7",
+            "display": "Enolase.neuron specific [Mass/volume] in Serum or Plasma"
+          },
+          {
+            "code": "19193-2",
+            "display": "Enolase.neuron specific [Units/volume] in Serum or Plasma"
+          },
+          {
+            "code": "19194-0",
+            "display": "Enolase.neuron specific [Units/volume] in Pleural fluid"
+          },
+          {
+            "code": "2225-1",
+            "display": "Enolase.neuron specific [Enzymatic activity/volume] in Serum or Plasma"
+          },
+          {
+            "code": "44802-7",
+            "display": "Enolase.neuron specific [Mass/volume] in Cerebral spinal fluid"
+          },
+          {
+            "code": "47053-4",
+            "display": "Enolase.neuron specific [Mass/volume] in Cerebral spinal fluid by Immunoassay"
+          },
+          {
+            "code": "48138-2",
+            "display": "Enolase.neuron specific [Mass/volume] in Serum or Plasma by Radioimmunoassay (RIA)"
+          },
+          {
+            "code": "48164-8",
+            "display": "Enolase.neuron specific [Mass/volume] in Body fluid"
+          },
+          {
+            "code": "57371-7",
+            "display": "Enolase.neuron specific [Mass/volume] in Serum or Plasma by Immunoassay"
+          },
+          {
+            "code": "68939-8",
+            "display": "Enolase.neuron specific [Mass/volume] in Pleural fluid"
+          },
+          {
+            "code": "68952-1",
+            "display": "Enolase.neuron specific [Mass/volume] in Pericardial fluid"
+          },
+          {
+            "code": "69560-1",
+            "display": "Enolase.neuron specific [Mass/volume] in Peritoneal fluid"
+          },
+          {
+            "code": "97744-7",
+            "display": "Enolase.neuron specific [Mass/volume] in Aspirate"
+          },
+          {
+            "code": "15072-2",
+            "display": "Gastrin [Moles/volume] in Serum or Plasma"
+          },
+          {
+            "code": "2333-3",
+            "display": "Gastrin [Mass/volume] in Serum or Plasma"
+          },
+          {
+            "code": "2960-3",
+            "display": "Somatostatin [Presence] in Plasma"
+          },
+          {
+            "code": "2961-1",
+            "display": "Somatostatin [Mass/volume] in Plasma"
+          },
+          {
+            "code": "49792-5",
+            "display": "Somatostatin [Moles/volume] in Plasma"
+          },
+          {
+            "code": "14918-7",
+            "display": "Thyroglobulin [Moles/volume] in Serum or Plasma"
+          },
+          {
+            "code": "3013-0",
+            "display": "Thyroglobulin [Mass/volume] in Serum or Plasma"
+          },
+          {
+            "code": "53920-5",
+            "display": "Thyroglobulin [Mass/volume] in Lymph node fine needle aspirate"
+          },
+          {
+            "code": "53922-1",
+            "display": "Thyroglobulin [Mass/volume] in Tissue fine needle aspirate"
+          },
+          {
+            "code": "97640-7",
+            "display": "Thyroglobulin [Moles/volume] in Tissue fine needle aspirate"
+          },
+          {
+            "code": "10861-3",
+            "display": "Progesterone receptor [Mass/mass] in Tissue"
+          },
+          {
+            "code": "16113-3",
+            "display": "Progesterone receptor [Interpretation] in Tissue"
+          },
+          {
+            "code": "31207-4",
+            "display": "Progesterone receptor [Moles/mass] in Tissue"
+          },
+          {
+            "code": "10873-8",
+            "display": "Beta-2-Microglobulin [Mass/time] in 24 hour Urine"
+          },
+          {
+            "code": "14626-6",
+            "display": "Beta-2-Microglobulin [Moles/volume] in Serum"
+          },
+          {
+            "code": "1951-3",
+            "display": "Beta-2-Microglobulin [Mass/volume] in Cerebral spinal fluid"
+          },
+          {
+            "code": "1952-1",
+            "display": "Beta-2-Microglobulin [Mass/volume] in Serum or Plasma"
+          },
+          {
+            "code": "1953-9",
+            "display": "Beta-2-Microglobulin [Mass/volume] in Urine"
+          },
+          {
+            "code": "32301-4",
+            "display": "Beta-2-Microglobulin [Moles/volume] in Cerebral spinal fluid"
+          },
+          {
+            "code": "32302-2",
+            "display": "Beta-2-Microglobulin [Moles/volume] in Urine"
+          },
+          {
+            "code": "39458-5",
+            "display": "Beta-2-Microglobulin [Moles/volume] in Body fluid"
+          },
+          {
+            "code": "43818-4",
+            "display": "Beta-2-Microglobulin [Presence] in Serum"
+          },
+          {
+            "code": "43819-2",
+            "display": "Beta-2-Microglobulin [Presence] in Urine"
+          },
+          {
+            "code": "43919-0",
+            "display": "Beta-2-Microglobulin [Presence] in Cerebral spinal fluid"
+          },
+          {
+            "code": "48166-3",
+            "display": "Beta-2-Microglobulin [Mass/volume] in Body fluid"
+          },
+          {
+            "code": "49081-3",
+            "display": "Beta-2-Microglobulin [Mass/volume] in Dialysis fluid"
+          },
+          {
+            "code": "50824-2",
+            "display": "Beta-2-Microglobulin [Moles/volume] in 24 hour Urine"
+          },
+          {
+            "code": "54356-1",
+            "display": "Beta-2-Microglobulin [Mass/volume] in 24 hour Urine"
+          },
+          {
+            "code": "56662-0",
+            "display": "Beta-2-Microglobulin [Moles/time] in 24 hour Urine"
+          },
+          {
+            "code": "59217-0",
+            "display": "Beta-2-Microglobulin [Mass/volume] in Peritoneal fluid"
+          },
+          {
+            "code": "59218-8",
+            "display": "Beta-2-Microglobulin [Mass/volume] in Pleural fluid"
+          },
+          {
+            "code": "76484-5",
+            "display": "Beta-2-Microglobulin [Moles/volume] in Serum or Plasma"
+          },
+          {
+            "code": "83076-0",
+            "display": "Beta-2-Microglobulin [Units/volume] in Serum or Plasma by Immunoassay"
+          },
+          {
+            "code": "83077-8",
+            "display": "Beta-2-Microglobulin [Mass/volume] in Urine by Immunoassay"
+          },
+          {
+            "code": "83078-6",
+            "display": "Beta-2-Microglobulin [Mass/volume] in Serum or Plasma by Immunoassay"
+          },
+          {
+            "code": "83079-4",
+            "display": "Beta-2-Microglobulin [Units/volume] in Urine by Immunoassay"
+          },
+          {
+            "code": "88711-7",
+            "display": "Beta-2-Microglobulin [Mass/volume] in Peritoneal dialysis fluid"
+          },
+          {
+            "code": "11053-6",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Red Blood Cells"
+          },
+          {
+            "code": "14403-0",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Gastric fluid"
+          },
+          {
+            "code": "14803-1",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Body fluid by Lactate to pyruvate reaction"
+          },
+          {
+            "code": "14804-9",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Serum or Plasma by Lactate to pyruvate reaction"
+          },
+          {
+            "code": "14805-6",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Serum or Plasma by Pyruvate to lactate reaction"
+          },
+          {
+            "code": "17041-5",
+            "display": "Lactate dehydrogenase [Presence] in Urine"
+          },
+          {
+            "code": "2527-0",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Amniotic fluid"
+          },
+          {
+            "code": "2528-8",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Cerebral spinal fluid"
+          },
+          {
+            "code": "2529-6",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Body fluid"
+          },
+          {
+            "code": "2530-4",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Pleural fluid"
+          },
+          {
+            "code": "2531-2",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Peritoneal fluid"
+          },
+          {
+            "code": "2532-0",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Serum or Plasma"
+          },
+          {
+            "code": "2533-8",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Synovial fluid"
+          },
+          {
+            "code": "2534-6",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Urine"
+          },
+          {
+            "code": "32324-6",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Specimen"
+          },
+          {
+            "code": "33367-4",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Pericardial fluid"
+          },
+          {
+            "code": "47678-8",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in 24 hour Urine"
+          },
+          {
+            "code": "47863-6",
+            "display": "Lactate dehydrogenase [Enzymatic activity/time] in 24 hour Urine"
+          },
+          {
+            "code": "57664-5",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Semen"
+          },
+          {
+            "code": "5921-2",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Dialysis fluid"
+          },
+          {
+            "code": "60017-1",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Body fluid by Pyruvate to lactate reaction"
+          },
+          {
+            "code": "60018-9",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Pericardial fluid by Pyruvate to lactate reaction"
+          },
+          {
+            "code": "60019-7",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Pericardial fluid by Lactate to pyruvate reaction"
+          },
+          {
+            "code": "60020-5",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Peritoneal fluid by Pyruvate to lactate reaction"
+          },
+          {
+            "code": "60021-3",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Pleural fluid by Pyruvate to lactate reaction"
+          },
+          {
+            "code": "60022-1",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Pleural fluid by Lactate to pyruvate reaction"
+          },
+          {
+            "code": "60023-9",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Cerebral spinal fluid by Pyruvate to lactate reaction"
+          },
+          {
+            "code": "60024-7",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Cerebral spinal fluid by Lactate to pyruvate reaction"
+          },
+          {
+            "code": "68387-0",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Peritoneal fluid by Lactate to pyruvate reaction"
+          },
+          {
+            "code": "68452-2",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Synovial fluid by Pyruvate to lactate reaction"
+          },
+          {
+            "code": "68453-0",
+            "display": "Lactate dehydrogenase [Enzymatic activity/volume] in Synovial fluid by Lactate to pyruvate reaction"
+          },
+          {
+            "code": "2007-3",
+            "display": "Cancer Ag 15-3 [Presence] in Serum or Plasma"
+          },
+          {
+            "code": "29153-4",
+            "display": "Cancer Ag 15-3 [Units/volume] in Body fluid"
+          },
+          {
+            "code": "50776-4",
+            "display": "Cancer Ag 15-3 [Units/volume] in Cerebral spinal fluid"
+          },
+          {
+            "code": "50777-2",
+            "display": "Cancer Ag 15-3 [Units/volume] in Pericardial fluid"
+          },
+          {
+            "code": "50778-0",
+            "display": "Cancer Ag 15-3 [Units/volume] in Peritoneal fluid"
+          },
+          {
+            "code": "6875-9",
+            "display": "Cancer Ag 15-3 [Units/volume] in Serum or Plasma"
+          },
+          {
+            "code": "83083-6",
+            "display": "Cancer Ag 15-3 [Units/volume] in Serum or Plasma by Immunoassay"
+          },
+          {
+            "code": "97749-6",
+            "display": "Cancer Ag 15-3 [Units/volume] in Aspirate"
+          },
+          {
+            "code": "2011-5",
+            "display": "Cancer Ag 242 [Presence] in Serum or Plasma"
+          },
+          {
+            "code": "17842-6",
+            "display": "Cancer Ag 27-29 [Units/volume] in Serum or Plasma"
+          },
+          {
+            "code": "19187-4",
+            "display": "Cancer Ag 27-29 [Units/volume] in Pleural fluid"
+          },
+          {
+            "code": "2012-3",
+            "display": "Cancer Ag 27-29 [Presence] in Serum or Plasma"
+          },
+          {
+            "code": "50782-2",
+            "display": "Cancer Ag 27-29 [Units/volume] in Cerebral spinal fluid"
+          },
+          {
+            "code": "2013-1",
+            "display": "Cancer Ag 50 [Presence] in Serum or Plasma"
+          },
+          {
+            "code": "34256-8",
+            "display": "Cancer Ag 50 [Units/volume] in Serum or Plasma"
+          },
+          {
+            "code": "19189-0",
+            "display": "Cancer Ag 549 [Units/volume] in Serum or Plasma"
+          },
+          {
+            "code": "19190-8",
+            "display": "Cancer Ag 549 [Units/volume] in Pleural fluid"
+          },
+          {
+            "code": "2014-9",
+            "display": "Cancer Ag 549 [Presence] in Serum or Plasma"
+          },
+          {
+            "code": "17843-4",
+            "display": "Cancer Ag 72-4 [Units/volume] in Serum or Plasma"
+          },
+          {
+            "code": "19164-3",
+            "display": "Cancer Ag 72-4 [Units/volume] in Pleural fluid"
+          },
+          {
+            "code": "2015-6",
+            "display": "Cancer Ag 72-4 [Presence] in Serum or Plasma"
+          },
+          {
+            "code": "34161-0",
+            "display": "Cancer Ag 72-4 [Units/volume] in Body fluid"
+          },
+          {
+            "code": "47012-0",
+            "display": "Cancer Ag 72-4 [Presence] in Tissue by Immune stain"
+          },
+          {
+            "code": "68924-0",
+            "display": "Cancer Ag 72-4 [Units/volume] in Peritoneal fluid"
+          },
+          {
+            "code": "68925-7",
+            "display": "Cancer Ag 72-4 [Units/volume] in Cerebral spinal fluid"
+          },
+          {
+            "code": "68926-5",
+            "display": "Cancer Ag 72-4 [Units/volume] in Pericardial fluid"
+          },
+          {
+            "code": "2506-4",
+            "display": "Isocitrate dehydrogenase [Enzymatic activity/volume] in Serum or Plasma"
+          },
+          {
+            "code": "72508-5",
+            "display": "UGT1A1 gene c.A(TA)7TAA(*28) [Presence] in Blood or Tissue by Molecular genetics method"
+          },
+          {
+            "code": "21015-3",
+            "display": "CD33 cells [#/volume] in Blood"
+          },
+          {
+            "code": "74837-6",
+            "display": "CD20 cells [#/volume] in Specimen"
+          },
+          {
+            "code": "9558-8",
+            "display": "CD20 cells [#/volume] in Blood"
+          },
+          {
+            "code": "10508-0",
+            "display": "Prostate specific Ag [Presence] in Tissue by Immune stain"
+          },
+          {
+            "code": "19195-7",
+            "display": "Prostate specific Ag [Units/volume] in Serum or Plasma"
+          },
+          {
+            "code": "19197-3",
+            "display": "Prostate specific Ag [Moles/volume] in Serum or Plasma"
+          },
+          {
+            "code": "19198-1",
+            "display": "Prostate specific Ag [Units/volume] in Semen"
+          },
+          {
+            "code": "19199-9",
+            "display": "Prostate specific Ag [Mass/volume] in Semen"
+          },
+          {
+            "code": "19200-5",
+            "display": "Prostate specific Ag [Moles/volume] in Semen"
+          },
+          {
+            "code": "2857-1",
+            "display": "Prostate specific Ag [Mass/volume] in Serum or Plasma"
+          },
+          {
+            "code": "34611-4",
+            "display": "Prostate specific Ag [Mass/volume] in Urine"
+          },
+          {
+            "code": "35741-8",
+            "display": "Prostate specific Ag [Mass/volume] in Serum or Plasma by Detection limit <= 0.01 ng/mL"
+          },
+          {
+            "code": "47738-0",
+            "display": "Prostate specific Ag [Mass/volume] in Body fluid"
+          },
+          {
+            "code": "59221-2",
+            "display": "Prostate specific Ag [Mass/volume] in Pleural fluid"
+          },
+          {
+            "code": "59223-8",
+            "display": "Prostate specific Ag [Mass/volume] in Peritoneal fluid"
+          },
+          {
+            "code": "59230-3",
+            "display": "Prostate specific Ag [Mass/volume] in Cerebral spinal fluid"
+          },
+          {
+            "code": "83112-3",
+            "display": "Prostate specific Ag [Mass/volume] in Serum or Plasma by Immunoassay"
+          },
+          {
+            "code": "13127-6",
+            "display": "Cancer Ag DM/70K [Units/volume] in Serum or Plasma"
+          },
+          {
+            "code": "13659-8",
+            "display": "Epidermal growth factor receptor [Mass/mass] in Tissue"
+          },
+          {
+            "code": "14050-9",
+            "display": "Epidermal growth factor receptor [Moles/mass] in Tissue"
+          },
+          {
+            "code": "21013-8",
+            "display": "CD22 cells [#/volume] in Blood"
+          },
+          {
+            "code": "14130-9",
+            "display": "Estrogen receptor [Moles/mass] in Tissue"
+          },
+          {
+            "code": "16112-5",
+            "display": "Estrogen receptor [Interpretation] in Tissue"
+          },
+          {
+            "code": "78205-2",
+            "display": "ALK gene rearrangements [Presence] in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78210-2",
+            "display": "ALK gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "91141-2",
+            "display": "TPMT activity in RBC by production of 6-MMP"
+          },
+          {
+            "code": "91142-0",
+            "display": "TPMT activity in RBC by production of 6-MMP riboside"
+          },
+          {
+            "code": "91143-8",
+            "display": "TPMT activity in RBC by production of 6-MTG riboside"
+          },
+          {
+            "code": "83059-6",
+            "display": "KRAS gene [VCF] in Cancer specimen by Sequencing"
+          },
+          {
+            "code": "80717-2",
+            "display": "B-cell CD27 and IgD subsets panel - Blood"
+          },
+          {
+            "code": "85299-6",
+            "display": "BRAF V600E mutant protein [Presence] in Cancer specimen by Immune stain"
+          },
+          {
+            "code": "32996-1",
+            "display": "HER2 [Mass/volume] in Serum"
+          },
+          {
+            "code": "42914-2",
+            "display": "HER2 [Mass/volume] in Serum by Immunoassay"
+          },
+          {
+            "code": "48676-1",
+            "display": "HER2 [Interpretation] in Tissue"
+          },
+          {
+            "code": "51981-9",
+            "display": "HER2 [Presence] in Serum by Immunoassay"
+          },
+          {
+            "code": "72382-5",
+            "display": "HER2 [Units/volume] in Tissue by Immunoassay"
+          },
+          {
+            "code": "72383-3",
+            "display": "HER2 [Presence] in Tissue by Immunoassay"
+          },
+          {
+            "code": "85319-2",
+            "display": "HER2 [Presence] in Breast cancer specimen by Immune stain"
+          },
+          {
+            "code": "28078-4",
+            "display": "Bladder tumor Ag [Presence] in Urine by Immunoassay"
+          },
+          {
+            "code": "28551-0",
+            "display": "Bladder tumor Ag [Units/volume] in Urine by Immunoassay"
+          },
+          {
+            "code": "31729-7",
+            "display": "Bladder tumor Ag [Presence] in Urine"
+          },
+          {
+            "code": "31730-5",
+            "display": "Bladder tumor Ag [Units/volume] in Urine"
+          },
+          {
+            "code": "80386-6",
+            "display": "Bladder tumor Ag [Presence] in Urine by Rapid immunoassay"
+          },
+          {
+            "code": "31134-0",
+            "display": "Nuclear matrix protein 22 [Units/volume] in Urine"
+          },
+          {
+            "code": "50666-7",
+            "display": "Nuclear matrix protein 22 [Presence] in Urine"
+          },
+          {
+            "code": "34444-0",
+            "display": "Acarboxyprothrombin [Mass/volume] in Serum or Plasma"
+          },
+          {
+            "code": "93768-0",
+            "display": "Acarboxyprothrombin [Units/volume] in Serum or Plasma"
+          },
+          {
+            "code": "41292-4",
+            "display": "Soluble mesothelin related proteins [Moles/volume] in Serum or Plasma"
+          },
+          {
+            "code": "43368-0",
+            "display": "Microsatellite instability [Identifier] in Tissue by Molecular genetics method Nominal"
+          },
+          {
+            "code": "62862-8",
+            "display": "Microsatellite instability [Presence] in Tissue by Immune stain"
+          },
+          {
+            "code": "81695-9",
+            "display": "Microsatellite instability [Interpretation] in Cancer specimen Qualitative"
+          },
+          {
+            "code": "43399-5",
+            "display": "JAK2 gene p.Val617Phe [Presence] in Blood or Tissue by Molecular genetics method"
+          },
+          {
+            "code": "72333-8",
+            "display": "JAK2 gene p.Val617Phe [Presence] in Bone marrow by Molecular genetics method"
+          },
+          {
+            "code": "31150-6",
+            "display": "ERBB2 gene duplication [Presence] in Tissue by FISH"
+          },
+          {
+            "code": "48674-6",
+            "display": "Genetic diseases [Identifier] in Blood or Tissue by FISH Nominal"
+          },
+          {
+            "code": "48684-5",
+            "display": "X and Y chromosome [Interpretation] in Blood or Marrow by FISH--post bone marrow transplant"
+          },
+          {
+            "code": "48730-6",
+            "display": "X linked heterotaxy [Identifier] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "49028-4",
+            "display": "Microdeletion syndromes [Identifier] in Blood or Tissue by FISH Nominal"
+          },
+          {
+            "code": "49039-1",
+            "display": "Subtelomere analysis [Identifier] in Blood or Tissue by FISH Nominal"
+          },
+          {
+            "code": "49040-9",
+            "display": "Subtelomere analysis [Interpretation] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "49063-1",
+            "display": "Microdeletion syndromes in Specimen by FISH Nominal"
+          },
+          {
+            "code": "49683-6",
+            "display": "ERBB2 gene copy number/Chromosome 17 copy number in Tissue by FISH"
+          },
+          {
+            "code": "50020-7",
+            "display": "Microdeletion syndromes in Blood or Tissue by FISH"
+          },
+          {
+            "code": "50659-2",
+            "display": "Chromosome analysis.interphase [Interpretation] in Bone marrow by FISH Narrative"
+          },
+          {
+            "code": "50684-0",
+            "display": "Chromosome analysis.interphase [Interpretation] in Blood by FISH Narrative"
+          },
+          {
+            "code": "51867-0",
+            "display": "t(9;22)(q34.1;q11)(ABL1,BCR) fusion transcript in Blood or Tissue by FISH"
+          },
+          {
+            "code": "53628-4",
+            "display": "20q chromosome deletion [Identifier] in Blood or Tissue by FISH Nominal"
+          },
+          {
+            "code": "55192-9",
+            "display": "Chromosome analysis.interphase [Interpretation] in Amniotic fluid by FISH Narrative"
+          },
+          {
+            "code": "55193-7",
+            "display": "Chromosome analysis.interphase [Interpretation] in Chorionic villus sample by FISH Narrative"
+          },
+          {
+            "code": "56030-0",
+            "display": "Karyotype [Identifier] in Urine by FISH Narrative"
+          },
+          {
+            "code": "56144-9",
+            "display": "CHIC2 gene 4q12 deletion in Blood or Tissue by FISH"
+          },
+          {
+            "code": "57038-2",
+            "display": "Chromosome 12 aneuploidy in Amniotic fluid or Chorionic villus sample by FISH Nominal"
+          },
+          {
+            "code": "57317-0",
+            "display": "Chromosome 13+18+21+X+Y aneuploidy in Amniotic fluid or Chorionic villus sample by FISH Nominal"
+          },
+          {
+            "code": "57318-8",
+            "display": "Chromosome 13+18+21+X+Y aneuploidy in Blood or Tissue by FISH Nominal"
+          },
+          {
+            "code": "57453-3",
+            "display": "Chromosome 18 aneuploidy in Amniotic fluid or Chorionic villus sample by FISH Nominal"
+          },
+          {
+            "code": "57454-1",
+            "display": "Chromosome 13 aneuploidy in Amniotic fluid or Chorionic villus sample by FISH Nominal"
+          },
+          {
+            "code": "57802-1",
+            "display": "Chromosome analysis.interphase [Interpretation] in Blood or Marrow by FISH Narrative"
+          },
+          {
+            "code": "57906-0",
+            "display": "9p21 chromosome deletion [Identifier] in Blood or Tissue by FISH Nominal"
+          },
+          {
+            "code": "59050-5",
+            "display": "Chromosome analysis.interphase [Interpretation] in Specimen by FISH Narrative"
+          },
+          {
+            "code": "59267-5",
+            "display": "Karyotype [Identifier] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "62344-7",
+            "display": "Chromosome analysis.metaphase panel - Blood by FISH"
+          },
+          {
+            "code": "62345-4",
+            "display": "Chromosome analysis.interphase panel - Blood by FISH"
+          },
+          {
+            "code": "62346-2",
+            "display": "Chromosome analysis.interphase panel - Amniotic fluid by FISH"
+          },
+          {
+            "code": "62347-0",
+            "display": "Chromosome analysis.prenatal panel by FISH"
+          },
+          {
+            "code": "62354-6",
+            "display": "Chromosome analysis.metaphase panel - Amniotic fluid by FISH"
+          },
+          {
+            "code": "62367-8",
+            "display": "Chromosome analysis panel by FISH"
+          },
+          {
+            "code": "63068-1",
+            "display": "TOP2A gene copy number/Chromosome 17 copy number in Tissue by FISH"
+          },
+          {
+            "code": "63070-7",
+            "display": "TOP2A gene 17q21-22 deletion and duplication mutation analysis [Presence] in Tissue by FISH"
+          },
+          {
+            "code": "66950-7",
+            "display": "MALT1 18q21 gene rearrangements in Blood or Tissue by FISH"
+          },
+          {
+            "code": "72652-1",
+            "display": "Subtelomere analysis.long arm [Interpretation] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "72653-9",
+            "display": "Subtelomere analysis.short arm [Interpretation] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "72654-7",
+            "display": "SNRPN gene 15q11 deletion and duplication mutation analysis [Identifier] in Blood or Tissue by FISH Nominal"
+          },
+          {
+            "code": "72725-5",
+            "display": "t(11;14)(q13.2;q32)(MYEOV,IGH) fusion transcript [Identifier] in Blood or Tissue by FISH Nominal"
+          },
+          {
+            "code": "72726-3",
+            "display": "t(4;14)(p16;q32)(FGFR3,IGH) fusion transcript [Identifier] in Blood or Tissue by FISH Nominal"
+          },
+          {
+            "code": "72728-9",
+            "display": "Del(13)(q14) [Identifier] in Blood or Tissue by FISH Nominal"
+          },
+          {
+            "code": "72824-6",
+            "display": "Del(17)(p13) [Identifier] in Blood or Tissue by FISH Nominal"
+          },
+          {
+            "code": "72827-9",
+            "display": "dic(9;20)(p11-13;q11)(wcp9+,wcp20+) [Identifier] in Blood or Tissue by FISH Nominal"
+          },
+          {
+            "code": "73558-9",
+            "display": "Staphylococcus aureus and Staphylococcus sp.coagulase negative rRNA [Identifier] by FISH in Positive blood culture"
+          },
+          {
+            "code": "73749-4",
+            "display": "4p16.3 chromosome deletion [Identifier] in Blood or Tissue by FISH Nominal"
+          },
+          {
+            "code": "73750-2",
+            "display": "RAI1 gene 17p11.2 deletion and duplication mutation analysis [Identifier] in Blood or Tissue by FISH Nominal"
+          },
+          {
+            "code": "73751-0",
+            "display": "5p15.2 (5p-) chromosome deletion [Identifier] in Blood or Tissue by FISH Nominal"
+          },
+          {
+            "code": "74034-0",
+            "display": "MAML2 11q21 gene rearrangements in Tissue by FISH"
+          },
+          {
+            "code": "74860-8",
+            "display": "ERBB2 gene copy number/nucleus in Tissue by FISH"
+          },
+          {
+            "code": "74861-6",
+            "display": "Chromosome 17 copy number/nucleus in Tissue by FISH"
+          },
+          {
+            "code": "74885-5",
+            "display": "ERBB2 gene (HER2) duplication associated observations panel - Tissue by FISH"
+          },
+          {
+            "code": "76065-2",
+            "display": "6p25 and 6q23 and 11q and 8q24 and 9p21 chromosome partial aneuploidy in Blood or Tissue by FISH"
+          },
+          {
+            "code": "77030-5",
+            "display": "t(1;19)(q23.3;p13.3)(PBX1,TCF3) fusion transcript in Blood or Tissue by FISH"
+          },
+          {
+            "code": "77031-3",
+            "display": "t(15;17)(q24.1;q21.1)(PML,RARA) fusion transcript in Blood or Tissue by FISH"
+          },
+          {
+            "code": "77032-1",
+            "display": "t(8;14)(q24;q32)(MYC,IGH) fusion transcript in Blood or Tissue by FISH"
+          },
+          {
+            "code": "77033-9",
+            "display": "t(14;16)(q32;q23)(IGH,MAF) fusion transcript in Blood or Tissue by FISH"
+          },
+          {
+            "code": "77034-7",
+            "display": "inv(16)(p13.1;q22.1)(MYH11,CBFB) fusion transcript in Blood or Tissue by FISH"
+          },
+          {
+            "code": "77035-4",
+            "display": "t(14;18)(q32;q21)(IGH,MALT1) fusion transcript in Blood or Tissue by FISH"
+          },
+          {
+            "code": "77036-2",
+            "display": "t(11;18)(q21;q21)(BIRC3,MALT1) fusion transcript in Blood or Tissue by FISH"
+          },
+          {
+            "code": "77037-0",
+            "display": "t(11;14)(q13;q32)(CCND1,IGH) fusion transcript in Blood or Tissue by FISH"
+          },
+          {
+            "code": "77038-8",
+            "display": "t(14;18)(q32;q21.3)(IGH,BCL2) fusion transcript in Blood or Tissue by FISH"
+          },
+          {
+            "code": "77039-6",
+            "display": "t(12;21)(p13;q22.3)(ETV6,RUNX1) fusion transcript in Blood or Tissue by FISH"
+          },
+          {
+            "code": "77040-4",
+            "display": "t(8;21)(q22;q22.3)(RUNX1T1,RUNX1) fusion transcript in Blood or Tissue by FISH"
+          },
+          {
+            "code": "77041-2",
+            "display": "inv(3)(q21;q26.2)+t(3;3)(q21;q26.2)(PSMD2,MECOM) fusion transcript in Blood or Tissue by FISH"
+          },
+          {
+            "code": "77042-0",
+            "display": "t(6;9)(p22;q34)(DEK,NUP214) fusion transcript in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78201-1",
+            "display": "4q12 chromosome region rearrangements [Identifier] in Blood or Tissue by FISH Nominal"
+          },
+          {
+            "code": "78202-9",
+            "display": "9q34 chromosome region deletion [Presence] in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78203-7",
+            "display": "BCL6 gene rearrangements [Presence] in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78204-5",
+            "display": "CCND1 gene duplication [Presence] in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78206-0",
+            "display": "4q12 chromosome region rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "78207-8",
+            "display": "9q34 chromosome region deletion [Interpretation] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "78208-6",
+            "display": "BCL6 gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "78209-4",
+            "display": "CCND1 gene duplication [Interpretation] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "78211-0",
+            "display": "Cells.4q12 chromosome region rearrangements/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78212-8",
+            "display": "Cells.9q34 chromosome region deletion/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78213-6",
+            "display": "Cells.BCL6 gene rearrangements/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78214-4",
+            "display": "Cells.CCND1 gene duplication/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78215-1",
+            "display": "MYC gene rearrangements [Presence] in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78216-9",
+            "display": "TRA+TRD gene rearrangements [Presence] in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78217-7",
+            "display": "RARA gene rearrangements [Presence] in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78218-5",
+            "display": "BCL2 gene rearrangements [Presence] in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78219-3",
+            "display": "MLL gene rearrangements [Presence] in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78220-1",
+            "display": "PDGFRB gene rearrangements [Presence] in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78221-9",
+            "display": "IGH gene rearrangements [Presence] in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78222-7",
+            "display": "MYC gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "78223-5",
+            "display": "TRA+TRD gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "78224-3",
+            "display": "RARA gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "78225-0",
+            "display": "BCL2 gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "78226-8",
+            "display": "MLL gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "78227-6",
+            "display": "PDGFRB gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "78228-4",
+            "display": "IGH gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "78229-2",
+            "display": "Cells.MYC gene rearrangements/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78230-0",
+            "display": "Cells.RARA gene rearrangements/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78231-8",
+            "display": "Cells.TRA+TRD gene rearrangements/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78232-6",
+            "display": "Cells.BCL2 gene rearrangements/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78233-4",
+            "display": "Cells.ALK gene rearrangements/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78234-2",
+            "display": "Cells.MLL gene rearrangements/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78235-9",
+            "display": "Cells.PDGFRB gene rearrangements/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78236-7",
+            "display": "Cells.IGH gene rearrangements/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78237-5",
+            "display": "Chromosome 8 copy number/nucleus in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78238-3",
+            "display": "Chromosome 3 copy number/nucleus in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78245-8",
+            "display": "MYB gene deletion [Presence] in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78342-3",
+            "display": "MYB gene deletion [Interpretation] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "78343-1",
+            "display": "Cells.MYB gene deletion/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78915-6",
+            "display": "FGFR1 gene rearrangements [Presence] in Blood or Tissue by FISH"
+          },
+          {
+            "code": "78916-4",
+            "display": "FGFR1 gene rearrangements [Interpretation] in Blood or Tissue by FISH Narrative"
+          },
+          {
+            "code": "78917-2",
+            "display": "Cells.FGFR1 gene rearrangements/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "79206-9",
+            "display": "inv(2)(p21;p23)(EML4,ALK) fusion transcript [Presence] in Blood or Tissue by FISH"
+          },
+          {
+            "code": "81710-6",
+            "display": "PTEN gene [Presence] in Cancer specimen by FISH"
+          },
+          {
+            "code": "81746-0",
+            "display": "Chromosome region 17p13.1 deletion in Blood or Tissue by FISH"
+          },
+          {
+            "code": "81747-8",
+            "display": "Chromosome region 6q22 rearrangements in Tissue by FISH"
+          },
+          {
+            "code": "81748-6",
+            "display": "Chromosome region Yp11.3 deletion AndOr rearrangement in Blood or Tissue by FISH"
+          },
+          {
+            "code": "81749-4",
+            "display": "Chromosome region 13q14 deletion in Bone marrow by FISH"
+          },
+          {
+            "code": "81751-0",
+            "display": "Chromosome 17p13.1 deletion and 14q32 rearrangements in Bone marrow by FISH"
+          },
+          {
+            "code": "81752-8",
+            "display": "Chromosome region 1q21 duplication in Bone marrow by FISH"
+          },
+          {
+            "code": "82238-7",
+            "display": "Chromosome region 15q11-13 deletion and duplication mutation analysis in Amniotic fluid or Chorionic villus sample by FISH"
+          },
+          {
+            "code": "82239-5",
+            "display": "Chromosome region 16p13.3 deletion in Blood or Tissue by FISH"
+          },
+          {
+            "code": "82240-3",
+            "display": "Chromosome region 16p13.3 deletion in Amniotic fluid or Chorionic villus sample by FISH"
+          },
+          {
+            "code": "82241-1",
+            "display": "Chromosome region 17p11.2 deletion in Amniotic fluid or Chorionic villus sample by FISH"
+          },
+          {
+            "code": "82242-9",
+            "display": "Chromosome region 17p13.3 deletion in Amniotic fluid or Chorionic villus sample by FISH"
+          },
+          {
+            "code": "82243-7",
+            "display": "Chromosome region 17p13.3 deletion in Blood or Tissue by FISH"
+          },
+          {
+            "code": "82244-5",
+            "display": "Chromosome region 1p36 deletion in Blood or Tissue by FISH"
+          },
+          {
+            "code": "82245-2",
+            "display": "Chromosome region 22q11.2 deletion and duplication mutation analysis in Amniotic fluid or Chorionic villus sample by FISH"
+          },
+          {
+            "code": "82246-0",
+            "display": "Chromosome region 22q11.2 deletion and duplication mutation analysis in Blood or Tissue by FISH"
+          },
+          {
+            "code": "82247-8",
+            "display": "Chromosome region 7q11.23 deletion in Amniotic fluid or Chorionic villus sample by FISH"
+          },
+          {
+            "code": "82248-6",
+            "display": "Chromosome region 7q11.23 deletion in Blood or Tissue by FISH"
+          },
+          {
+            "code": "82249-4",
+            "display": "Chromosome region 8q23.3-24.13 deletion in Blood or Tissue by FISH"
+          },
+          {
+            "code": "82250-2",
+            "display": "Chromosome region 1p subtelomere and 1p36 deletion and 1q25 rearrangement in Blood or Tissue by FISH"
+          },
+          {
+            "code": "82251-0",
+            "display": "Chromosome 3 and 7 and 17 aneuploidy and chromosome region 9p21 deletion in Urine by FISH"
+          },
+          {
+            "code": "82253-6",
+            "display": "JAG1 gene deletion in Blood or Tissue by FISH"
+          },
+          {
+            "code": "82256-9",
+            "display": "Chromosome 12 trisomy and chromosome region 11q22.3 and 13q14 and 17p13.1 deletion in Blood or Tissue by FISH"
+          },
+          {
+            "code": "82257-7",
+            "display": "SRY gene deletion in Blood or Tissue by FISH"
+          },
+          {
+            "code": "82258-5",
+            "display": "Subtelomere analysis in Bone marrow by FISH"
+          },
+          {
+            "code": "82295-7",
+            "display": "Chromosome region Xp22.33 AndOr Yp11.32 deletion and duplication mutation analysis in Blood or Tissue by FISH"
+          },
+          {
+            "code": "82597-6",
+            "display": "Chromosome painting analysis in Blood or Tissue by FISH"
+          },
+          {
+            "code": "84912-5",
+            "display": "Cells.chromosome region 5q31 deletion/Cells counted in Bone marrow by FISH"
+          },
+          {
+            "code": "84913-3",
+            "display": "Cells.chromosome 12 trisomy/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "84914-1",
+            "display": "Cells.chromosome region 13q14 deletion/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "84915-8",
+            "display": "Cells.chromosome region 11q22.3 deletion/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "84916-6",
+            "display": "Cells.chromosome region 17p13.1 deletion/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "84917-4",
+            "display": "Chromosome Y aneuploidy [Presence] in Amniotic fluid or Chorionic villus sample by FISH"
+          },
+          {
+            "code": "84918-2",
+            "display": "Chromosome X aneuploidy [Presence] in Amniotic fluid or Chorionic villus sample by FISH"
+          },
+          {
+            "code": "84919-0",
+            "display": "Chromosome 21 aneuploidy [Presence] in Amniotic fluid or Chorionic villus sample by FISH"
+          },
+          {
+            "code": "84920-8",
+            "display": "Cells.chromosome region 5q31 deletion/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "84921-6",
+            "display": "Cells.chromosome region 7q31 deletion/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "84922-4",
+            "display": "Cells.chromosome 7 monosomy/Cells counted in Blood or Tissue by FISH"
+          },
+          {
+            "code": "85318-4",
+            "display": "ERBB2 gene duplication [Presence] in Breast cancer specimen by FISH"
+          },
+          {
+            "code": "86239-1",
+            "display": "Cells.chromosome 3 monosomy/Cells counted in Cancer specimen by FISH"
+          },
+          {
+            "code": "87436-2",
+            "display": "Chromosome X and Y aneuploidy in Blood or Tissue by FISH"
+          },
+          {
+            "code": "90043-1",
+            "display": "t(14;20)(q32;q12)(IGH,MAFB) fusion transcript in Blood or Tissue by FISH"
+          },
+          {
+            "code": "90926-7",
+            "display": "MET gene amplification in Blood or Tissue by FISH"
+          },
+          {
+            "code": "90927-5",
+            "display": "RET gene rearrangements in Blood or Tissue by FISH"
+          },
+          {
+            "code": "92905-9",
+            "display": "Chromosome 7 copy number/nucleus in Blood or Tissue by FISH"
+          },
+          {
+            "code": "92906-7",
+            "display": "MET gene copy number/nucleus in Blood or Tissue by FISH"
+          },
+          {
+            "code": "92907-5",
+            "display": "MET gene copy number/Chromosome 7 copy number in Blood or Tissue by FISH"
+          },
+          {
+            "code": "93796-1",
+            "display": "MYCN gene amplification in Blood or Tissue by FISH"
+          },
+          {
+            "code": "93797-9",
+            "display": "MYCN gene copy number/Chromosome 2 copy number in Tissue by FISH"
+          },
+          {
+            "code": "93798-7",
+            "display": "MYCN gene copy number/nucleus in Tissue by FISH"
+          },
+          {
+            "code": "93799-5",
+            "display": "Chromosome 2 copy number/nucleus in Tissue by FISH"
+          },
+          {
+            "code": "93800-1",
+            "display": "1p/1q chromosome deletion [# Ratio] in Tissue by FISH"
+          },
+          {
+            "code": "93801-9",
+            "display": "Chromosome 1 polysomy [Presence] in Tissue by FISH"
+          },
+          {
+            "code": "93802-7",
+            "display": "19q/19p chromosome deletion [# Ratio] in Tissue by FISH"
+          },
+          {
+            "code": "93803-5",
+            "display": "Chromosome 19 polysomy [Presence] in Tissue by FISH"
+          },
+          {
+            "code": "93804-3",
+            "display": "Chromosome 12 copy number/nucleus in Tissue by FISH"
+          },
+          {
+            "code": "93805-0",
+            "display": "MDM2 gene copy number/nucleus in Tissue by FISH"
+          },
+          {
+            "code": "93806-8",
+            "display": "EWSR1 gene rearrangements in Tissue by FISH"
+          },
+          {
+            "code": "93807-6",
+            "display": "FOXO1 gene rearrangements in Tissue by FISH"
+          },
+          {
+            "code": "93808-4",
+            "display": "MDM2 gene amplification in Tissue by FISH"
+          },
+          {
+            "code": "93809-2",
+            "display": "MDM2 gene copy number/Chromosome 12 copy number in Tissue by FISH"
+          },
+          {
+            "code": "93810-0",
+            "display": "SS18 gene rearrangements in Tissue by FISH"
+          },
+          {
+            "code": "94338-1",
+            "display": "Chromosome 13+15+16+18+21+22+X+Y aneuploidy in Products of Conception by FISH"
+          },
+          {
+            "code": "95069-1",
+            "display": "Chromosome 1q and 9 and 11 and 15 aneuploidy and 13q deletion in Bone marrow by FISH"
+          },
+          {
+            "code": "95070-9",
+            "display": "Chromosome 9 and 11 and 15 aneuploidy in Bone marrow by FISH"
+          },
+          {
+            "code": "95071-7",
+            "display": "Chromosome region 14q32 rearrangements in Bone marrow by FISH"
+          },
+          {
+            "code": "95551-8",
+            "display": "Chromosome region 17p11.2 deletion in Blood or Tissue by FISH"
+          },
+          {
+            "code": "95552-6",
+            "display": "4p16.3 chromosome deletion in Blood or Tissue by FISH"
+          },
+          {
+            "code": "95553-4",
+            "display": "5p15.2 (5p-) chromosome deletion [Identifier] in Blood or Tissue by FISH"
+          },
+          {
+            "code": "95779-5",
+            "display": "TFE3 gene rearrangements in Tissue by FISH"
+          },
+          {
+            "code": "95780-3",
+            "display": "TFEB gene rearrangements in Tissue by FISH"
+          },
+          {
+            "code": "95783-7",
+            "display": "ETV6 gene rearrangements in Blood or Marrow by FISH"
+          },
+          {
+            "code": "95784-5",
+            "display": "FGFR2 gene rearrangements in Tissue by FISH"
+          },
+          {
+            "code": "96494-0",
+            "display": "ABL1 and ABL2 and PDGFRB gene rearrangements in Blood or Tissue by FISH"
+          },
+          {
+            "code": "96495-7",
+            "display": "ABL2 gene rearrangements in Blood or Tissue by FISH"
+          },
+          {
+            "code": "96893-3",
+            "display": "ERBB2 gene duplication in Tumor by FISH"
+          },
+          {
+            "code": "98014-4",
+            "display": "Plasma cell proliferation analysis in Bone marrow by FISH"
+          },
+          {
+            "code": "49490-6",
+            "display": "BCR-ABL1 b2a2 fusion protein [Presence] in Blood or Tissue by Molecular genetics method"
+          },
+          {
+            "code": "55180-4",
+            "display": "Human epididymis protein 4 [Moles/volume] in Serum or Plasma"
+          },
+          {
+            "code": "96044-3",
+            "display": "Human epididymis protein 4 [Mass/volume] in Serum or Plasma"
+          },
+          {
+            "code": "60588-1",
+            "display": "t(15;17)(q24.1;q21.1)(PML,RARA) bcr2 fusion transcript [Presence] in Blood or Tissue by Molecular genetics method"
+          },
+          {
+            "code": "72211-6",
+            "display": "t(15;17)(q24.1;q21.1)(PML,RARA) bcr2 fusion transcript/control transcript [# Ratio] in Bone marrow by Molecular genetics method"
+          },
+          {
+            "code": "72215-7",
+            "display": "t(15;17)(q24.1;q21.1)(PML,RARA) bcr2 fusion transcript/control transcript [# Ratio] in Blood or Tissue by Molecular genetics method"
+          },
+          {
+            "code": "10432-3",
+            "display": "CD30 Ag [Presence] in Tissue by Immune stain"
+          },
+          {
+            "code": "10560-1",
+            "display": "Carcinoembryonic Ag [Units/volume] in Semen"
+          },
+          {
+            "code": "12515-3",
+            "display": "Carcinoembryonic Ag [Mass/volume] in Body fluid"
+          },
+          {
+            "code": "19166-8",
+            "display": "Carcinoembryonic Ag [Units/volume] in Serum or Plasma"
+          },
+          {
+            "code": "19167-6",
+            "display": "Carcinoembryonic Ag [Moles/volume] in Serum or Plasma"
+          },
+          {
+            "code": "19168-4",
+            "display": "Carcinoembryonic Ag [Units/volume] in Pleural fluid"
+          },
+          {
+            "code": "19169-2",
+            "display": "Carcinoembryonic Ag [Mass/volume] in Pleural fluid"
+          },
+          {
+            "code": "19170-0",
+            "display": "Carcinoembryonic Ag [Moles/volume] in Pleural fluid"
+          },
+          {
+            "code": "2037-0",
+            "display": "Carcinoembryonic Ag [Mass/volume] in Cerebral spinal fluid"
+          },
+          {
+            "code": "2038-8",
+            "display": "Carcinoembryonic Ag [Mass/volume] in Semen"
+          },
+          {
+            "code": "2039-6",
+            "display": "Carcinoembryonic Ag [Mass/volume] in Serum or Plasma"
+          },
+          {
+            "code": "40621-5",
+            "display": "Carcinoembryonic Ag [Mass/volume] in Pericardial fluid"
+          },
+          {
+            "code": "40622-3",
+            "display": "Carcinoembryonic Ag [Mass/volume] in Peritoneal fluid"
+          },
+          {
+            "code": "83085-1",
+            "display": "Carcinoembryonic Ag [Mass/volume] in Serum or Plasma by Immunoassay"
+          },
+          {
+            "code": "14230-7",
+            "display": "Cells.progesterone receptor/100 cells in Tissue by Immune stain"
+          },
+          {
+            "code": "40557-1",
+            "display": "Progesterone receptor Ag [Presence] in Tissue by Immune stain"
+          },
+          {
+            "code": "85325-9",
+            "display": "Cells.progesterone receptor/100 cells in Breast cancer specimen by Immune stain"
+          },
+          {
+            "code": "85331-7",
+            "display": "Progesterone receptor fluorescence intensity [Type] in Breast cancer specimen by Immune stain"
+          },
+          {
+            "code": "85339-0",
+            "display": "Progesterone receptor Ag [Presence] in Breast cancer specimen by Immune stain"
+          },
+          {
+            "code": "13485-8",
+            "display": "Beta-2-Microglobulin/Creatinine [Mass Ratio] in Urine"
+          },
+          {
+            "code": "39773-7",
+            "display": "Beta-2-Microglobulin/Creatinine [Molar ratio] in Urine"
+          },
+          {
+            "code": "44303-6",
+            "display": "Beta-2-Microglobulin/Creatinine [Mass Ratio] in 24 hour Urine"
+          },
+          {
+            "code": "56786-7",
+            "display": "Beta-2-Microglobulin.tumor marker [Mass/volume] in Serum"
+          },
+          {
+            "code": "59177-6",
+            "display": "Beta-2-Microglobulin/Creatinine [Ratio] in Urine"
+          },
+          {
+            "code": "87708-4",
+            "display": "Beta-2-Microglobulin [Mass/volume] in Serum or Plasma --post dialysis"
+          },
+          {
+            "code": "93729-2",
+            "display": "Beta-2-Microglobulin/Creatinine [Ratio] in 24 hour Urine"
+          },
+          {
+            "code": "14967-4",
+            "display": "CD33 Abnormal blood cells/Abnormal blood cells.total in Blood"
+          },
+          {
+            "code": "20601-1",
+            "display": "CD33 cells/100 cells in Unspecified specimen"
+          },
+          {
+            "code": "51155-0",
+            "display": "CD33 blasts/100 blasts in Bone marrow"
+          },
+          {
+            "code": "51156-8",
+            "display": "CD33 blasts/100 blasts in Unspecified specimen"
+          },
+          {
+            "code": "51157-6",
+            "display": "CD33 blasts [Units/volume] in Bone marrow"
+          },
+          {
+            "code": "51158-4",
+            "display": "CD33 blasts [Units/volume] in Blood"
+          },
+          {
+            "code": "51159-2",
+            "display": "CD33 blasts [Units/volume] in Unspecified specimen"
+          },
+          {
+            "code": "51291-3",
+            "display": "CD33 cells/100 cells in Tissue"
+          },
+          {
+            "code": "51292-1",
+            "display": "CD33 cells/100 cells in Cerebral spinal fluid"
+          },
+          {
+            "code": "51293-9",
+            "display": "CD33 cells/100 cells in Bone marrow"
+          },
+          {
+            "code": "51294-7",
+            "display": "CD33 cells/100 cells in Body fluid"
+          },
+          {
+            "code": "8102-6",
+            "display": "CD33 cells/100 cells in Blood"
+          },
+          {
+            "code": "10438-0",
+            "display": "CD20 Ag [Presence] in Tissue by Immune stain"
+          },
+          {
+            "code": "13842-0",
+            "display": "CD20 blasts/100 blasts in Blood"
+          },
+          {
+            "code": "14966-6",
+            "display": "CD20 Abnormal blood cells/Abnormal blood cells.total in Blood"
+          },
+          {
+            "code": "20595-5",
+            "display": "CD20 cells/100 cells in Unspecified specimen"
+          },
+          {
+            "code": "51115-4",
+            "display": "CD20 blasts/100 blasts in Bone marrow"
+          },
+          {
+            "code": "51116-2",
+            "display": "CD20 blasts/100 blasts in Unspecified specimen"
+          },
+          {
+            "code": "57418-6",
+            "display": "CD20 cells/100 cells in Body fluid"
+          },
+          {
+            "code": "8119-0",
+            "display": "CD20 cells/100 cells in Blood"
+          },
+          {
+            "code": "29596-4",
+            "display": "CD25 Ag [Presence] in Tissue by Immune stain"
+          },
+          {
+            "code": "32581-1",
+            "display": "Epidermal growth factor receptor Ag [Presence] in Tissue by Immune stain"
+          },
+          {
+            "code": "39004-7",
+            "display": "Epidermal growth factor receptor Ag [Presence] in Tissue"
+          },
+          {
+            "code": "42782-3",
+            "display": "Epidermal growth factor receptor.phosphorylated Ag [Presence] in Tissue by Immune stain"
+          },
+          {
+            "code": "14017-8",
+            "display": "CD22 cells/100 cells in Blood"
+          },
+          {
+            "code": "20596-3",
+            "display": "CD22 cells/100 cells in Unspecified specimen"
+          },
+          {
+            "code": "42875-5",
+            "display": "CD22 cells/100 cells in Body fluid"
+          },
+          {
+            "code": "51124-6",
+            "display": "CD22 blasts/100 blasts in Bone marrow"
+          },
+          {
+            "code": "51125-3",
+            "display": "CD22 blasts/100 blasts in Blood"
+          },
+          {
+            "code": "51126-1",
+            "display": "CD22 blasts/100 blasts in Unspecified specimen"
+          },
+          {
+            "code": "51127-9",
+            "display": "CD22 blasts [Units/volume] in Bone marrow"
+          },
+          {
+            "code": "51128-7",
+            "display": "CD22 blasts [Units/volume] in Blood"
+          },
+          {
+            "code": "51129-5",
+            "display": "CD22 blasts [Units/volume] in Unspecified specimen"
+          },
+          {
+            "code": "14228-1",
+            "display": "Cells.estrogen receptor/100 cells in Tissue by Immune stain"
+          },
+          {
+            "code": "40556-3",
+            "display": "Estrogen receptor Ag [Presence] in Tissue by Immune stain"
+          },
+          {
+            "code": "85310-1",
+            "display": "Estrogen receptor fluorescence intensity [Type] in Breast cancer specimen by Immune stain"
+          },
+          {
+            "code": "85329-1",
+            "display": "Cells.estrogen receptor/100 cells in Breast cancer specimen by Immune stain"
+          },
+          {
+            "code": "85337-4",
+            "display": "Estrogen receptor Ag [Presence] in Breast cancer specimen by Immune stain"
+          },
+          {
+            "code": "21636-6",
+            "display": "BRCA1 gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal"
+          },
+          {
+            "code": "21637-4",
+            "display": "BRCA1 gene.c.185 del AG [presence] in Blood or Tissue by Molecular genetics method"
+          },
+          {
+            "code": "21638-2",
+            "display": "BRCA1 gene c.5382insC [Presence] in Blood or Tissue by Molecular genetics method"
+          },
+          {
+            "code": "21639-0",
+            "display": "BRCA1 gene mutations tested for in Blood or Tissue by Molecular genetics method Nominal"
+          },
+          {
+            "code": "79207-7",
+            "display": "BRCA1 gene mutation analysis limited to known familial mutations in Blood or Tissue by Molecular genetics method"
+          },
+          {
+            "code": "21702-6",
+            "display": "KRAS gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal"
+          },
+          {
+            "code": "21703-4",
+            "display": "KRAS gene mutations tested for in Blood or Tissue by Molecular genetics method Nominal"
+          },
+          {
+            "code": "53620-1",
+            "display": "KRAS gene mutations found [Identifier] in Bone marrow by Molecular genetics method Nominal"
+          },
+          {
+            "code": "75974-6",
+            "display": "KRAS gene targeted mutation analysis in Blood or Tissue by Molecular genetics method"
+          },
+          {
+            "code": "81420-2",
+            "display": "KRAS and NRAS gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal"
+          },
+          {
+            "code": "82535-6",
+            "display": "KRAS gene full mutation analysis in Blood or Tissue by Sequencing"
+          },
+          {
+            "code": "85509-8",
+            "display": "KRAS gene mutations found [Identifier] in Colorectal cancer specimen by Molecular genetics method Nominal"
+          },
+          {
+            "code": "40552-2",
+            "display": "CD117 Ag [Presence] in Tissue by Immune stain"
+          },
+          {
+            "code": "51183-2",
+            "display": "CD117 Ag [Presence] in Bone marrow by Immune stain"
+          },
+          {
+            "code": "51184-0",
+            "display": "CD117 Ag [Presence] in Blood by Immune stain"
+          },
+          {
+            "code": "51185-7",
+            "display": "CD117 Ag [Presence] in Unspecified specimen by Immune stain"
+          },
+          {
+            "code": "80706-5",
+            "display": "CD27+IgD- cells/100 CD19+CD20+ cells in Blood"
+          },
+          {
+            "code": "83052-1",
+            "display": "PD-L1 by clone 22C3 [Presence] in Tissue by Immune stain"
+          },
+          {
+            "code": "83053-9",
+            "display": "Cells.programmed cell death ligand 1/100 viable tumor cells in Tissue by Immune stain"
+          },
+          {
+            "code": "83054-7",
+            "display": "PD-L1 by clone 22C3 [Interpretation] in Tissue by Immune stain Narrative"
+          },
+          {
+            "code": "83055-4",
+            "display": "PD-L1 by clone 28-8 [Presence] in Tissue by Immune stain"
+          },
+          {
+            "code": "83056-2",
+            "display": "PD-L1 by clone 28-8 [Interpretation] in Tissue by Immune stain Narrative"
+          },
+          {
+            "code": "83057-0",
+            "display": "PD-L1 by clone SP142 [Presence] in Tissue by Immune stain"
+          },
+          {
+            "code": "85147-7",
+            "display": "PD-L1 by clone 22C3 in Tissue by Immune stain Report"
+          },
+          {
+            "code": "85148-5",
+            "display": "PD-L1 by clone 28-8 in Tissue by Immune stain Report"
+          },
+          {
+            "code": "85149-3",
+            "display": "PD-L1 by clone SP142 in Tissue by Immune stain Report"
+          },
+          {
+            "code": "21640-8",
+            "display": "BRCA2 gene c.6174delT [Presence] in Blood or Tissue by Molecular genetics method"
+          },
+          {
+            "code": "38530-2",
+            "display": "BRCA2 gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal"
+          },
+          {
+            "code": "38531-0",
+            "display": "BRCA2 gene mutations tested for in Blood or Tissue by Molecular genetics method Nominal"
+          },
+          {
+            "code": "79208-5",
+            "display": "BRCA2 gene mutation analysis limited to known familial mutations in Blood or Tissue by Molecular genetics method"
+          },
+          {
+            "code": "45284-7",
+            "display": "DPYD gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal"
+          },
+          {
+            "code": "47958-4",
+            "display": "FLT3 gene targeted mutation analysis in Blood or Tissue by Molecular genetics method"
+          },
+          {
+            "code": "54447-8",
+            "display": "FLT3 gene targeted mutation analysis in Bone marrow by Molecular genetics method"
+          },
+          {
+            "code": "72520-0",
+            "display": "FLT3 gene p.Asp835+Ile836 [Presence] in Blood or Tissue by Molecular genetics method"
+          },
+          {
+            "code": "79210-1",
+            "display": "FLT3 gene internal tandem duplication [Presence] in Blood or Tissue by Molecular genetics method"
+          },
+          {
+            "code": "85100-6",
+            "display": "FLT3 gene internal tandem duplication [Presence] in Bone marrow by Molecular genetics method"
+          },
+          {
+            "code": "92843-2",
+            "display": "FLT3 gene p.Asp835 mutations [Presence] in Blood or Tissue by Molecular genetics method"
+          },
+          {
+            "code": "48972-4",
+            "display": "FGFR2 gene+FGFR3 gene mutations found [Identifier] in Blood or Tissue by Molecular genetics method Nominal"
+          }
+        ]
+      }
+    ]
+  },
+  "expansion": {
+    "timestamp": "2022-05-20T09:57:21-04:00",
+    "total": 512,
+    "contains": [
+      {
+        "system": "http://loinc.org",
+        "code": "62320-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "92006-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "92007-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "92008-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "69361-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "69362-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19163-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2009-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "24108-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "26924-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50779-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50780-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50781-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83084-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "97750-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14041-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19174-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19175-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "20415-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2111-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2113-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2114-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21198-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "29154-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "43799-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "43800-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "55868-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "55869-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "56497-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "66762-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "66763-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "10334-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "11210-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "15156-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "15157-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19165-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2006-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "40618-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "48677-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50775-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59040-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "68923-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83082-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "97743-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "15035-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "1992-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "47369-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "75709-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "25587-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "30169-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "53047-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59220-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59226-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59227-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59241-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "9811-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "15060-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19193-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19194-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2225-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "44802-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "47053-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "48138-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "48164-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57371-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "68939-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "68952-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "69560-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "97744-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "15072-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2333-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2960-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2961-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "49792-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14918-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3013-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "53920-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "53922-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "97640-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "10861-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16113-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "31207-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "10873-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14626-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "1951-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "1952-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "1953-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "32301-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "32302-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "39458-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "43818-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "43819-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "43919-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "48166-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "49081-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50824-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "54356-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "56662-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59217-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59218-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "76484-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83076-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83077-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83078-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83079-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "88711-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "11053-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14403-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14803-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14804-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14805-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "17041-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2527-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2528-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2529-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2530-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2531-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2532-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2533-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2534-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "32324-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "33367-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "47678-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "47863-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57664-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "5921-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "60017-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "60018-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "60019-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "60020-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "60021-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "60022-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "60023-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "60024-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "68387-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "68452-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "68453-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2007-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "29153-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50776-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50777-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50778-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "6875-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83083-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "97749-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2011-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "17842-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19187-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2012-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50782-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2013-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "34256-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19189-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19190-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2014-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "17843-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19164-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2015-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "34161-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "47012-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "68924-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "68925-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "68926-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2506-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72508-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21015-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "74837-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "9558-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "10508-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19195-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19197-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19198-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19199-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19200-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2857-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "34611-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "35741-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "47738-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59221-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59223-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59230-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83112-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "13127-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "13659-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14050-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21013-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14130-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16112-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78205-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78210-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "91141-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "91142-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "91143-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83059-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "80717-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85299-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "32996-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "42914-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "48676-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51981-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72382-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72383-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85319-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "28078-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "28551-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "31729-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "31730-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "80386-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "31134-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50666-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "34444-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93768-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "41292-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "43368-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "62862-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "81695-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "43399-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72333-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "31150-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "48674-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "48684-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "48730-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "49028-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "49039-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "49040-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "49063-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "49683-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50020-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50659-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "50684-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51867-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "53628-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "55192-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "55193-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "56030-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "56144-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57038-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57317-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57318-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57453-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57454-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57802-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57906-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59050-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59267-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "62344-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "62345-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "62346-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "62347-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "62354-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "62367-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "63068-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "63070-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "66950-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72652-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72653-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72654-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72725-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72726-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72728-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72824-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72827-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "73558-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "73749-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "73750-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "73751-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "74034-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "74860-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "74861-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "74885-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "76065-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77030-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77031-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77032-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77033-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77034-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77035-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77036-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77037-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77038-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77039-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77040-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77041-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "77042-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78201-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78202-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78203-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78204-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78206-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78207-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78208-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78209-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78211-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78212-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78213-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78214-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78215-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78216-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78217-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78218-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78219-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78220-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78221-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78222-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78223-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78224-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78225-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78226-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78227-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78228-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78229-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78230-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78231-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78232-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78233-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78234-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78235-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78236-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78237-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78238-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78245-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78342-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78343-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78915-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78916-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78917-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "79206-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "81710-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "81746-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "81747-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "81748-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "81749-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "81751-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "81752-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82238-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82239-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82240-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82241-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82242-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82243-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82244-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82245-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82246-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82247-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82248-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82249-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82250-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82251-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82253-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82256-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82257-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82258-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82295-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82597-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84912-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84913-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84914-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84915-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84916-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84917-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84918-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84919-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84920-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84921-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "84922-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85318-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "86239-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "87436-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "90043-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "90926-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "90927-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "92905-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "92906-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "92907-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93796-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93797-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93798-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93799-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93800-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93801-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93802-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93803-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93804-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93805-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93806-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93807-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93808-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93809-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93810-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "94338-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95069-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95070-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95071-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95551-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95552-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95553-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95779-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95780-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95783-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "95784-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "96494-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "96495-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "96893-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "98014-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "49490-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "55180-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "96044-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "60588-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72211-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72215-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "10432-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "10560-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "12515-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19166-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19167-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19168-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19169-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19170-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2037-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2038-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "2039-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "40621-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "40622-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83085-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14230-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "40557-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85325-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85331-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85339-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "13485-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "39773-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "44303-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "56786-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "59177-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "87708-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "93729-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14967-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "20601-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51155-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51156-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51157-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51158-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51159-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51291-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51292-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51293-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51294-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "8102-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "10438-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "13842-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14966-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "20595-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51115-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51116-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "57418-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "8119-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "29596-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "32581-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "39004-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "42782-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14017-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "20596-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "42875-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51124-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51125-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51126-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51127-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51128-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51129-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "14228-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "40556-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85310-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85329-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85337-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21636-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21637-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21638-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21639-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "79207-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21702-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21703-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "53620-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "75974-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "81420-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "82535-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85509-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "40552-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51183-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51184-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51185-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "80706-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83052-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83053-9"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83054-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83055-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83056-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "83057-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85147-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85148-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85149-3"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "21640-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "38530-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "38531-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "79208-5"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "45284-7"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "47958-4"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "54447-8"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72520-0"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "79210-1"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "85100-6"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "92843-2"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "48972-4"
+      }
+    ]
+  },
+  "resourceType": "ValueSet"
+}


### PR DESCRIPTION
Updates the `SyntheaToSTU2` mapper to utilize the correct `mCODE Tumor Marker Test` profile, also expands the filter for that  mapper to include all Observations with a `code` that is found in the corresponding value set. 