### PR TITLE
mCODE STU2 Condition Stage fix, radiotherapy course summary fixes

### DIFF
--- a/src/mapping/mappers/SyntheaToSTU2.js
+++ b/src/mapping/mappers/SyntheaToSTU2.js
@@ -146,16 +146,22 @@ const resourceMapping = {
           resource.code.coding[0].code = 'USCRS-33529';
           resource.code.coding[0].display =
             'Radiotherapy Course of Treatment (regime/therapy)';
-
-          resource.category = resource.category || [];
-          resource.category.unshift({
-            coding: [
+          resource.code.coding[0].system =
+            'http://hl7.org/fhir/us/mcode/CodeSystem/snomed-requested-cs';
+          resource.category = resource.category || {};
+          if (resource.category.coding) {
+            resource.category.coding.unshift({
+              system: 'http://snomed.info/sct',
+              code: '108290001',
+            });
+          } else {
+            resource.category.coding = [
               {
                 system: 'http://snomed.info/sct',
                 code: '108290001',
               },
-            ],
-          });
+            ];
+          }
         }
 
         return resource;
@@ -392,9 +398,9 @@ const resourceMapping = {
             type: {
               coding: [
                 {
-                  system: 'http://snomed.info/sct',
-                  code: '260998006',
-                  display: 'Clinical staging (qualifier value)',
+                  system: 'http://loinc.org',
+                  code: '21908-9',
+                  display: 'Stage group.clinical Cancer',
                 },
               ],
             },
@@ -530,9 +536,9 @@ const resourceMapping = {
             type: {
               coding: [
                 {
-                  system: 'http://snomed.info/sct',
-                  code: '261023001',
-                  display: 'Pathological staging (qualifier value)',
+                  system: 'http://loinc.org',
+                  code: '21902-2',
+                  display: 'Stage group.pathology Cancer',
                 },
               ],
             },


### PR DESCRIPTION
Addresses three errors that were noticed while validating patient bundles in the SyntheaToSTU2 mapper:

1. The [RadiotherapyCourseSummary profile](http://hl7.org/fhir/us/mcode/STU2/StructureDefinition-mcode-radiotherapy-course-summary.html) specifies that it's `code` element must use the system [`http://hl7.org/fhir/us/mcode/CodeSystem/snomed-requested-cs`](http://hl7.org/fhir/us/mcode/STU2/CodeSystem-snomed-requested-cs.html).
2. The `category` element on the [RadiotherapyCourseSummary profile](http://hl7.org/fhir/us/mcode/STU2/StructureDefinition-mcode-radiotherapy-course-summary.html) has a max cardinality of 1 and should be an object, not an array. 
3. The `stage.type` element on the [Primary Cancer Condition profile](http://hl7.org/fhir/us/mcode/STU2/StructureDefinition-mcode-primary-cancer-condition.html) must adhere to the [Staging Type for Stage Group Value Set](http://hl7.org/fhir/us/mcode/STU2/ValueSet-mcode-observation-codes-stage-group-vs.html)