### PR TITLE
Change package.json main value to index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "Dylan Hall <dehall@mitre.org>",
     "Dylan Phelan <dtphelan1@gmail.com>"
   ],
-  "main": "dist/app.bundle.js",
+  "main": "src/index.js",
   "repository": "git@github.com:standardhealth/fhir-mapper.git",
   "author": "Matthew Gramigna <mgramigna@mitre.org>",
   "license": "MIT",


### PR DESCRIPTION
Current `main` causes errors when importing into a CLI based app. Changing to `src/index.js` would allow use of mappers in other projects.